### PR TITLE
awkward1 to awkward

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         python-version:
         - 2.7
         - 3.6
-        - 3.9
+        - 3.8
     name: Check Python ${{ matrix.python-version }}
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,17 +9,6 @@ on:
     - develop
 
 jobs:
-  pre-commit:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    - uses: actions/setup-python@v2
-    - uses: pre-commit/action@v2.0.0
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-
   checks:
     runs-on: ubuntu-latest
     strategy:
@@ -28,7 +17,7 @@ jobs:
         python-version:
         - 2.7
         - 3.6
-        - 3.8
+        - 3.9
     name: Check Python ${{ matrix.python-version }}
     steps:
     - uses: actions/checkout@v2
@@ -51,7 +40,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Get Conda
-      uses: goanpeca/setup-miniconda@v1
+      uses: conda-incubator/setup-miniconda@v2
       with:
         environment-file: environment.yml
         activate-environment: vector
@@ -65,17 +54,12 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
 
     - name: Install wheel and sdist requirements
-      run: python -m pip install "setuptools>=42.0" "setuptools_scm[toml]>=3.4" "wheel"
+      run: python -m pip install "build"
 
-    - name: Build sdist
-      run: python setup.py sdist
-
-    - name: Build wheel
-      run: python -m pip wheel . -w wheels && cp wheels/vector*any.whl dist/
+    - name: Build sdist and wheel
+      run: python -m build
 
     - uses: actions/upload-artifact@v2
       with:

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup
 
 extras = {
     "dev": [
-        "awkward1>=0.2.29",
+        "awkward>=1.0.0",
         "uproot==3.*",
         'numba>=0.50; python_version>="3"',
         "scikit-hep-testdata>=0.2.0",

--- a/src/vector/awkward/lorentz/xyzt.py
+++ b/src/vector/awkward/lorentz/xyzt.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, print_function
 
 from typing import Any, Dict
 
-import awkward1 as ak
+import awkward as ak
 
 import numpy as np
 

--- a/src/vector/numba/awkward/lorentz/xyzt.py
+++ b/src/vector/numba/awkward/lorentz/xyzt.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, print_function
 
 import operator
 
-import awkward1 as ak
+import awkward as ak
 
 from vector.awkward.lorentz.xyzt import behavior
 from vector.numba.lorentz.xyzt import LorentzXYZTType

--- a/tests/awkward_tests/__init__.py
+++ b/tests/awkward_tests/__init__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 import pytest
 
-pytest.importorskip("awkward1")
+pytest.importorskip("awkward")

--- a/tests/awkward_tests/test_demo.py
+++ b/tests/awkward_tests/test_demo.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-import awkward1 as ak
+import awkward as ak
 
 from pytest import approx
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,4 @@
 # -*- coding: utf-8 -*-
-
-import numpy as np
-
 import pytest
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,9 +13,7 @@ def ak_HZZ_example():
 
     tree = uproot.open(skhep_testdata.data_path("uproot-HZZ.root"))["events"]
 
-    x, y, z, t = tree.arrays(
-        ["Muon_Px", "Muon_Py", "Muon_Pz", "Muon_E"], how=tuple
-    )
+    x, y, z, t = tree.arrays(["Muon_Px", "Muon_Py", "Muon_Pz", "Muon_E"], how=tuple)
 
     offsets = x.layout.offsets
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,21 +9,22 @@ import pytest
 def ak_HZZ_example():
     skhep_testdata = pytest.importorskip("skhep_testdata")
     uproot = pytest.importorskip("uproot")
-    ak = pytest.importorskip("awkward1")
+    ak = pytest.importorskip("awkward")
 
     tree = uproot.open(skhep_testdata.data_path("uproot-HZZ.root"))["events"]
 
     x, y, z, t = tree.arrays(
-        ["Muon_Px", "Muon_Py", "Muon_Pz", "Muon_E"], outputtype=tuple
+        ["Muon_Px", "Muon_Py", "Muon_Pz", "Muon_E"], how=tuple
     )
 
-    offsets = ak.layout.Index64(x.offsets)
+    offsets = x.layout.offsets
+
     content = ak.layout.RecordArray(
         [
-            ak.layout.NumpyArray(x.content.astype(np.float64)),
-            ak.layout.NumpyArray(y.content.astype(np.float64)),
-            ak.layout.NumpyArray(z.content.astype(np.float64)),
-            ak.layout.NumpyArray(t.content.astype(np.float64)),
+            ak.layout.NumpyArray(ak.values_astype(x.layout.content, "float64")),
+            ak.layout.NumpyArray(ak.values_astype(y.layout.content, "float64")),
+            ak.layout.NumpyArray(ak.values_astype(z.layout.content, "float64")),
+            ak.layout.NumpyArray(ak.values_astype(t.layout.content, "float64")),
         ],
         keys=["x", "y", "z", "t"],
         parameters={"__record__": "LorentzXYZT"},

--- a/tests/numba_tests/test_awkward.py
+++ b/tests/numba_tests/test_awkward.py
@@ -3,7 +3,7 @@ import numba
 
 import pytest
 
-ak = pytest.importorskip("awkward1")
+ak = pytest.importorskip("awkward")
 
 from vector.numba.awkward.lorentz.xyzt import behavior  # noqa: E402
 from vector.single.lorentz.xyzt import LorentzXYZTFree  # noqa: E402


### PR DESCRIPTION
Since awkward 1.0.0 has been released, changing `awkward1` &rarr; `awkward`.
Without these changes any code using both awkward1 (e.g. from `vector`) and awkward 1.0 will crash.

Also updated the pytest fixture for the new syntax since the last awkward1 change.
