### PR TITLE
chore: drop Python 2.7 & 3.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,16 +50,12 @@ jobs:
       run: python -m pytest tests/root_tests -ra
 
   dist:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v1
-    - uses: actions/setup-python@v2
-
-    - name: Install wheel and sdist requirements
-      run: python -m pip install "build"
 
     - name: Build sdist and wheel
-      run: python -m build
+      run: pipx run --spec build pyproject-build
 
     - uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-        - 2.7
         - 3.6
         - 3.8
         - 3.9

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,10 @@
 repos:
+- repo: https://github.com/asottile/pyupgrade
+  rev: v2.10.0
+  hooks:
+  - id: pyupgrade
+    args: [--py36-plus]
+
 - repo: https://github.com/psf/black
   rev: 20.8b1
   hooks:
@@ -18,13 +24,6 @@ repos:
   - id: requirements-txt-fixer
   - id: trailing-whitespace
 
-- repo: https://github.com/asottile/pyupgrade
-  rev: v2.10.0
-  hooks:
-  - id: pyupgrade
-    # args: [--py36-plus]
-
-
 - repo: https://github.com/PyCQA/isort
   rev: 5.7.0
   hooks:
@@ -34,7 +33,6 @@ repos:
   rev: v1.16.0
   hooks:
   - id: setup-cfg-fmt
-    args: [--min-py3-version, "3.5"]
 
 - repo: https://github.com/mgedmin/check-manifest
   rev: "0.46"

--- a/README.md
+++ b/README.md
@@ -15,10 +15,6 @@
 Vector classes and utilities. See [CONTRIBUTING.md](./.github/CONTRIBUTING.md)
 for information on setting up a development environment.
 
-Python 2 is partially supported; the simple, NumPy, and Awkward backends
-support Python 2. The Numba and AwkwardNumba (and TensorFlow, in the future)
-backends do not.
-
 
 
 [gitter-badge]:  https://badges.gitter.im/Scikit-HEP/vector.svg

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Configuration file for the Sphinx documentation builder.
 #
 # This file only contains a selection of the most common options. For a full

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,10 +19,8 @@ classifiers =
     License :: OSI Approved :: BSD License
     Operating System :: OS Independent
     Programming Language :: Python
-    Programming Language :: Python :: 2
-    Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
@@ -35,9 +33,8 @@ keywords =
 packages = find:
 install_requires =
     numpy>=1.13.3
-    typing;python_version<"3.5"
     typing_extensions;python_version<"3.8"
-python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*
+python_requires = >=3.6
 package_dir =
     =src
 
@@ -73,9 +70,6 @@ ignore_missing_imports = True
 
 [mypy-awkward]
 ignore_missing_imports = True
-
-[bdist_wheel]
-universal = 1
 
 [tool.check-manifest]
 ignore =

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 # Copyright (c) 2019-2020, Jonas Eschle, Jim Pivarski, Eduardo Rodrigues, and Henry Schreiner.
 #
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE

--- a/src/vector/__init__.py
+++ b/src/vector/__init__.py
@@ -1,10 +1,8 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2019-2020, Jonas Eschle, Jim Pivarski, Eduardo Rodrigues, and Henry Schreiner.
 #
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-from __future__ import absolute_import, division, print_function
 
 # Convenient access to the version number
 from .version import version as __version__

--- a/src/vector/awkward/__init__.py
+++ b/src/vector/awkward/__init__.py
@@ -1,7 +1,4 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2019-2020, Jonas Eschle, Jim Pivarski, Eduardo Rodrigues, and Henry Schreiner.
 #
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
-
-from __future__ import absolute_import, division, print_function

--- a/src/vector/awkward/lorentz/__init__.py
+++ b/src/vector/awkward/lorentz/__init__.py
@@ -1,7 +1,4 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2019-2020, Jonas Eschle, Jim Pivarski, Eduardo Rodrigues, and Henry Schreiner.
 #
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
-
-from __future__ import absolute_import, division, print_function

--- a/src/vector/awkward/lorentz/xyzt.py
+++ b/src/vector/awkward/lorentz/xyzt.py
@@ -1,10 +1,8 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2019-2020, Jonas Eschle, Jim Pivarski, Eduardo Rodrigues, and Henry Schreiner.
 #
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-from __future__ import absolute_import, division, print_function
 
 import numbers
 from typing import Any, Dict

--- a/src/vector/awkward/lorentz/xyzt.py
+++ b/src/vector/awkward/lorentz/xyzt.py
@@ -40,7 +40,7 @@ def _create_behavior_r(function):
 
 
 # Define some behaviors for Lorentz vectors.
-behavior = dict()  # type: Dict[Any, Any]
+behavior: Dict[Any, Any] = dict()
 
 # Any records with __record__ = "LorentzXYZT" will be mapped to LorentzXYZT instances.
 behavior["LorentzXYZT"] = LorentzXYZT

--- a/src/vector/core/__init__.py
+++ b/src/vector/core/__init__.py
@@ -1,10 +1,8 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2019-2020, Jonas Eschle, Jim Pivarski, Eduardo Rodrigues, and Henry Schreiner.
 #
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-from __future__ import absolute_import, division, print_function
 
 # This is the *only* place numpy is imported; it is always used from here.
 import numpy

--- a/src/vector/core/lorentz/__init__.py
+++ b/src/vector/core/lorentz/__init__.py
@@ -1,7 +1,4 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2019-2020, Jonas Eschle, Jim Pivarski, Eduardo Rodrigues, and Henry Schreiner.
 #
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
-
-from __future__ import absolute_import, division, print_function

--- a/src/vector/core/lorentz/all.py
+++ b/src/vector/core/lorentz/all.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2019-2020, Jonas Eschle, Jim Pivarski, Eduardo Rodrigues, and Henry Schreiner.
 #
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
@@ -9,8 +8,6 @@
 
 """
 
-
-from __future__ import absolute_import, division, print_function
 
 from typing import TYPE_CHECKING
 

--- a/src/vector/core/lorentz/all.py
+++ b/src/vector/core/lorentz/all.py
@@ -9,41 +9,31 @@
 """
 
 
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from vector.protocols.lorentz import LorentzVector, Scalar
-
 from vector.core import numpy as np
+from vector.protocols.lorentz import LorentzVector, Scalar
 
 
-def p2(vec):
-    # type: (LorentzVector) -> Scalar
+def p2(vec: LorentzVector) -> Scalar:
     return vec.x ** 2 + vec.y ** 2 + vec.z ** 2
 
 
-def p(vec):
-    # type: (LorentzVector) -> Scalar
+def p(vec: LorentzVector) -> Scalar:
     return np.sqrt(p2(vec))
 
 
-def beta(vec):
-    # type: (LorentzVector) -> Scalar
+def beta(vec: LorentzVector) -> Scalar:
     return p2(vec) / vec.t
 
 
-def gamma(vec):
-    # type: (LorentzVector) -> Scalar
+def gamma(vec: LorentzVector) -> Scalar:
     return 1 / np.sqrt(1 - beta(vec) ** 2)
 
 
-def rapidity(vec):
-    # type: (LorentzVector) -> Scalar
+def rapidity(vec: LorentzVector) -> Scalar:
     return 0.5 * np.log((vec.t + vec.z) / (vec.t - vec.z))
 
 
-def delta_r2(vec, other):
-    # type: (LorentzVector, LorentzVector) -> Scalar
+def delta_r2(vec: LorentzVector, other: LorentzVector) -> Scalar:
     """Return :math:`\\Delta R^2` the distance squared in (eta,phi) space with another Lorentz vector, defined as:
     :math:`\\Delta R^2 = (\\Delta \\eta)^2 + (\\Delta \\phi)^2`
     """
@@ -51,8 +41,7 @@ def delta_r2(vec, other):
     return (vec.eta - other.eta) ** 2 + delta_phi ** 2
 
 
-def delta_r(vec, other):
-    # type: (LorentzVector, LorentzVector) -> Scalar
+def delta_r(vec: LorentzVector, other: LorentzVector) -> Scalar:
     """Return :math:`\\Delta R` the distance in (eta,phi) space with another Lorentz vector, defined as:
     :math:`\\Delta R = \\sqrt{(\\Delta \\eta)^2 + (\\Delta \\phi)^2}`
     """

--- a/src/vector/core/lorentz/xyzt.py
+++ b/src/vector/core/lorentz/xyzt.py
@@ -4,12 +4,8 @@
 # or https://github.com/scikit-hep/vector for details.
 
 
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from vector.protocols.lorentz import LorentzVector, LorentzTuple, Scalar
-
 from vector.core import numpy as np
+from vector.protocols.lorentz import LorentzTuple, LorentzVector, Scalar
 
 # Functions that return a value
 
@@ -19,8 +15,7 @@ from vector.core import numpy as np
 # t: already included
 
 
-def add(left, right):
-    # type: (LorentzVector, LorentzVector) -> LorentzTuple
+def add(left: LorentzVector, right: LorentzVector) -> LorentzTuple:
     x = left.x + right.x
     y = left.y + right.y
     z = left.z + right.z
@@ -29,8 +24,7 @@ def add(left, right):
     return x, y, z, t
 
 
-def add_scalar(left, right):
-    # type: (LorentzVector, Scalar) -> LorentzTuple
+def add_scalar(left: LorentzVector, right: Scalar) -> LorentzTuple:
     x = left.x + right
     y = left.y + right
     z = left.z + right
@@ -39,38 +33,31 @@ def add_scalar(left, right):
     return x, y, z, t
 
 
-def dot(left, right):
-    # type: (LorentzVector, LorentzVector) -> Scalar
+def dot(left: LorentzVector, right: LorentzVector) -> Scalar:
     return left.t * right.t - left.x * right.x - left.y * right.y - left.z * right.z
 
 
-def multiply_scalar(left, right):
-    # type: (LorentzVector, Scalar) -> LorentzTuple
+def multiply_scalar(left: LorentzVector, right: Scalar) -> LorentzTuple:
     return left.x * right, left.y * right, left.z * right, left.t * right
 
 
-def pt(vec):
-    # type: (LorentzVector) -> Scalar
+def pt(vec: LorentzVector) -> Scalar:
     return np.sqrt(vec.x ** 2 + vec.y ** 2)
 
 
-def eta(vec):
-    # type: (LorentzVector) -> Scalar
+def eta(vec: LorentzVector) -> Scalar:
     return np.arcsinh(vec.z / np.sqrt(vec.x ** 2 + vec.y ** 2))
 
 
-def phi(vec):
-    # type: (LorentzVector) -> Scalar
+def phi(vec: LorentzVector) -> Scalar:
     return np.arctan2(vec.y, vec.x)
 
 
 # mass
-def mag(vec):
-    # type: (LorentzVector) -> Scalar
+def mag(vec: LorentzVector) -> Scalar:
     return np.sqrt(vec.t ** 2 - vec.x ** 2 - vec.y ** 2 - vec.z ** 2)
 
 
 # mass2
-def mag2(vec):
-    # type: (LorentzVector) -> Scalar
+def mag2(vec: LorentzVector) -> Scalar:
     return vec.t ** 2 - vec.x ** 2 - vec.y ** 2 - vec.z ** 2

--- a/src/vector/core/lorentz/xyzt.py
+++ b/src/vector/core/lorentz/xyzt.py
@@ -1,10 +1,8 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2019-2020, Jonas Eschle, Jim Pivarski, Eduardo Rodrigues, and Henry Schreiner.
 #
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-from __future__ import absolute_import, division, print_function
 
 from typing import TYPE_CHECKING
 

--- a/src/vector/mixins/__init__.py
+++ b/src/vector/mixins/__init__.py
@@ -1,7 +1,4 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2019-2020, Jonas Eschle, Jim Pivarski, Eduardo Rodrigues, and Henry Schreiner.
 #
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
-
-from __future__ import absolute_import, division, print_function

--- a/src/vector/mixins/lorentz/__init__.py
+++ b/src/vector/mixins/lorentz/__init__.py
@@ -1,7 +1,4 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2019-2020, Jonas Eschle, Jim Pivarski, Eduardo Rodrigues, and Henry Schreiner.
 #
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
-
-from __future__ import absolute_import, division, print_function

--- a/src/vector/mixins/lorentz/xyzt.py
+++ b/src/vector/mixins/lorentz/xyzt.py
@@ -4,15 +4,12 @@
 # or https://github.com/scikit-hep/vector for details.
 
 
-from typing import TYPE_CHECKING, TypeVar, overload
+from typing import TypeVar, overload
 
 import numpy as np
 
 import vector.core.lorentz.xyzt
-
-if TYPE_CHECKING:
-    from vector.protocols.lorentz import LorentzVector, Scalar
-
+from vector.protocols.lorentz import LorentzVector, Scalar
 
 T = TypeVar("T")
 
@@ -23,8 +20,7 @@ class LorentzXYZTMethodMixin:
     """
 
     @property
-    def pt(self):
-        # type: (LorentzVector) -> Scalar
+    def pt(self: LorentzVector) -> Scalar:
         r"""
         The traverse momentum.
 
@@ -41,8 +37,7 @@ class LorentzXYZTMethodMixin:
             return vector.core.lorentz.xyzt.pt(self)
 
     @property
-    def eta(self):
-        # type: (LorentzVector) -> Scalar
+    def eta(self: LorentzVector) -> Scalar:
         r"""
         The
 
@@ -60,8 +55,7 @@ class LorentzXYZTMethodMixin:
             return vector.core.lorentz.xyzt.eta(self)
 
     @property
-    def phi(self):
-        # type: (LorentzVector) -> Scalar
+    def phi(self: LorentzVector) -> Scalar:
         r"""
         Notes
         -----
@@ -77,25 +71,21 @@ class LorentzXYZTMethodMixin:
             return vector.core.lorentz.xyzt.phi(self)
 
     @property
-    def mass(self):
-        # type: (LorentzVector) -> Scalar
+    def mass(self: LorentzVector) -> Scalar:
         with np.errstate(invalid="ignore"):
             return vector.core.lorentz.xyzt.mag(self)
 
     @property
-    def mag(self):
-        # type: (LorentzVector) -> Scalar
+    def mag(self: LorentzVector) -> Scalar:
         with np.errstate(invalid="ignore"):
             return vector.core.lorentz.xyzt.mag(self)
 
     @property
-    def mag2(self):
-        # type: (LorentzVector) -> Scalar
+    def mag2(self: LorentzVector) -> Scalar:
         with np.errstate(invalid="ignore"):
             return vector.core.lorentz.xyzt.mag2(self)
 
-    def dot(self, other):
-        # type: (LorentzVector, LorentzVector) -> Scalar
+    def dot(self: LorentzVector, other: LorentzVector) -> Scalar:
         return vector.core.lorentz.xyzt.dot(self, other)
 
 
@@ -105,14 +95,12 @@ class LorentzXYZTDunderMixin:
     """
 
     @overload
-    def __add__(self, other):
-        # type: (LorentzVector, LorentzVector) -> LorentzVector
-        pass
+    def __add__(self: LorentzVector, other: LorentzVector) -> LorentzVector:
+        ...
 
     @overload
-    def __add__(self, other):
-        # type: (LorentzVector, Scalar) -> LorentzVector
-        pass
+    def __add__(self: LorentzVector, other: Scalar) -> LorentzVector:
+        ...
 
     def __add__(self, other):
         if isinstance(other, LorentzXYZTMethodMixin):
@@ -121,14 +109,12 @@ class LorentzXYZTDunderMixin:
             return self.__class__(*vector.core.lorentz.xyzt.add_scalar(self, other))
 
     @overload
-    def __mul__(self, other):
-        # type: (LorentzVector, LorentzVector) -> Scalar
-        pass
+    def __mul__(self: LorentzVector, other: LorentzVector) -> Scalar:
+        ...
 
     @overload
-    def __mul__(self, other):
-        # type: (LorentzVector, Scalar) -> LorentzVector
-        pass
+    def __mul__(self: LorentzVector, other: Scalar) -> LorentzVector:
+        ...
 
     def __mul__(self, other):
         if isinstance(other, LorentzXYZTMethodMixin):
@@ -138,10 +124,8 @@ class LorentzXYZTDunderMixin:
                 *vector.core.lorentz.xyzt.multiply_scalar(self, other)
             )
 
-    def __radd__(self, other):
-        # type: (LorentzVector, Scalar) -> LorentzVector
+    def __radd__(self: LorentzVector, other: Scalar) -> LorentzVector:
         return self.__class__(*vector.core.lorentz.xyzt.add_scalar(self, other))
 
-    def __rmul__(self, other):
-        # type: (LorentzVector, Scalar) -> LorentzVector
+    def __rmul__(self: LorentzVector, other: Scalar) -> LorentzVector:
         return self.__class__(*vector.core.lorentz.xyzt.multiply_scalar(self, other))

--- a/src/vector/mixins/lorentz/xyzt.py
+++ b/src/vector/mixins/lorentz/xyzt.py
@@ -1,10 +1,8 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2019-2020, Jonas Eschle, Jim Pivarski, Eduardo Rodrigues, and Henry Schreiner.
 #
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-from __future__ import absolute_import, division, print_function
 
 from typing import TYPE_CHECKING, TypeVar, overload
 

--- a/src/vector/numba/__init__.py
+++ b/src/vector/numba/__init__.py
@@ -1,7 +1,4 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2019-2020, Jonas Eschle, Jim Pivarski, Eduardo Rodrigues, and Henry Schreiner.
 #
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
-
-from __future__ import absolute_import, division, print_function

--- a/src/vector/numba/awkward/__init__.py
+++ b/src/vector/numba/awkward/__init__.py
@@ -1,7 +1,4 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2019-2020, Jonas Eschle, Jim Pivarski, Eduardo Rodrigues, and Henry Schreiner.
 #
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
-
-from __future__ import absolute_import, division, print_function

--- a/src/vector/numba/awkward/lorentz/__init__.py
+++ b/src/vector/numba/awkward/lorentz/__init__.py
@@ -1,7 +1,4 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2019-2020, Jonas Eschle, Jim Pivarski, Eduardo Rodrigues, and Henry Schreiner.
 #
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
-
-from __future__ import absolute_import, division, print_function

--- a/src/vector/numba/awkward/lorentz/xyzt.py
+++ b/src/vector/numba/awkward/lorentz/xyzt.py
@@ -1,10 +1,8 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2019-2020, Jonas Eschle, Jim Pivarski, Eduardo Rodrigues, and Henry Schreiner.
 #
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-from __future__ import absolute_import, division, print_function
 
 import operator
 

--- a/src/vector/numba/lorentz/__init__.py
+++ b/src/vector/numba/lorentz/__init__.py
@@ -1,7 +1,4 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2019-2020, Jonas Eschle, Jim Pivarski, Eduardo Rodrigues, and Henry Schreiner.
 #
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
-
-from __future__ import absolute_import, division, print_function

--- a/src/vector/numba/lorentz/xyzt.py
+++ b/src/vector/numba/lorentz/xyzt.py
@@ -1,10 +1,8 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2019-2020, Jonas Eschle, Jim Pivarski, Eduardo Rodrigues, and Henry Schreiner.
 #
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-from __future__ import absolute_import, division, print_function
 
 import operator
 

--- a/src/vector/numpy/__init__.py
+++ b/src/vector/numpy/__init__.py
@@ -1,7 +1,4 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2019-2020, Jonas Eschle, Jim Pivarski, Eduardo Rodrigues, and Henry Schreiner.
 #
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
-
-from __future__ import absolute_import, division, print_function

--- a/src/vector/numpy/lorentz/__init__.py
+++ b/src/vector/numpy/lorentz/__init__.py
@@ -1,7 +1,4 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2019-2020, Jonas Eschle, Jim Pivarski, Eduardo Rodrigues, and Henry Schreiner.
 #
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
-
-from __future__ import absolute_import, division, print_function

--- a/src/vector/numpy/lorentz/xyzt.py
+++ b/src/vector/numpy/lorentz/xyzt.py
@@ -1,10 +1,8 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2019-2020, Jonas Eschle, Jim Pivarski, Eduardo Rodrigues, and Henry Schreiner.
 #
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-from __future__ import absolute_import, division, print_function
 
 from typing import TYPE_CHECKING, Any, cast
 
@@ -32,7 +30,7 @@ class LorentzXYZT(
 
     def __repr__(self):
         # type: () -> str
-        return "Lxyz({}, {}, {}, {})".format(self.x, self.y, self.z, self.t)
+        return f"Lxyz({self.x}, {self.y}, {self.z}, {self.t})"
 
     def __getitem__(self, attr):
         # type: (str) -> ArrayLike
@@ -40,7 +38,7 @@ class LorentzXYZT(
         if attr in ("x", "y", "z", "t"):
             return getattr(self, attr)
         else:
-            raise ValueError("key {} does not exist in x,y,z,t".format(attr))
+            raise ValueError(f"key {attr} does not exist in x,y,z,t")
 
 
 if TYPE_CHECKING:

--- a/src/vector/numpy/lorentz/xyzt.py
+++ b/src/vector/numpy/lorentz/xyzt.py
@@ -10,6 +10,8 @@ import vector.mixins.lorentz.xyzt
 from vector.core import numpy as np
 
 if TYPE_CHECKING:
+    from numpy.typing import ArrayLike
+else:
     ArrayLike = Any
 
 
@@ -17,8 +19,7 @@ class LorentzXYZT(
     vector.mixins.lorentz.xyzt.LorentzXYZTMethodMixin,
     vector.mixins.lorentz.xyzt.LorentzXYZTDunderMixin,
 ):
-    def __init__(self, x, y, z, t):
-        # type: (ArrayLike, ArrayLike, ArrayLike, ArrayLike) -> None
+    def __init__(self, x: ArrayLike, y: ArrayLike, z: ArrayLike, t: ArrayLike) -> None:
         """
         Notes
         =====
@@ -28,12 +29,10 @@ class LorentzXYZT(
 
         self.x, self.y, self.z, self.t = np.broadcast_arrays(x, y, z, t)
 
-    def __repr__(self):
-        # type: () -> str
+    def __repr__(self) -> str:
         return f"Lxyz({self.x}, {self.y}, {self.z}, {self.t})"
 
-    def __getitem__(self, attr):
-        # type: (str) -> ArrayLike
+    def __getitem__(self, attr: str) -> ArrayLike:
         # It has to behave the same way as the bound objects or users will get confused.
         if attr in ("x", "y", "z", "t"):
             return getattr(self, attr)
@@ -44,4 +43,4 @@ class LorentzXYZT(
 if TYPE_CHECKING:
     from vector.protocols.lorentz import LorentzVector
 
-    _ = cast(LorentzXYZT, None)  # type: LorentzVector
+    _: LorentzVector = cast(LorentzXYZT, None)

--- a/src/vector/protocols/lorentz.py
+++ b/src/vector/protocols/lorentz.py
@@ -1,5 +1,3 @@
-from __future__ import annotations  # type: ignore
-
 from typing import Protocol, Tuple, TypeVar, overload
 
 Self = TypeVar("Self", bound="Scalar")
@@ -75,22 +73,22 @@ class LorentzVector(Protocol):
         ...
 
     @overload
-    def __add__(self, other: LorentzVector) -> LorentzVector:
+    def __add__(self, other: "LorentzVector") -> "LorentzVector":
         ...
 
     @overload
-    def __add__(self, other: Scalar) -> LorentzVector:
+    def __add__(self, other: Scalar) -> "LorentzVector":
         ...
 
     def __add__(self, other):
         ...
 
     @overload
-    def __mul__(self, other: LorentzVector) -> Scalar:
+    def __mul__(self, other: "LorentzVector") -> Scalar:
         ...
 
     @overload
-    def __mul__(self, other: Scalar) -> LorentzVector:
+    def __mul__(self, other: Scalar) -> "LorentzVector":
         ...
 
     def __mul__(self, other):

--- a/src/vector/protocols/lorentz.py
+++ b/src/vector/protocols/lorentz.py
@@ -1,4 +1,10 @@
-from typing import Protocol, Tuple, TypeVar, overload
+import sys
+from typing import Tuple, TypeVar, overload
+
+if sys.version_info < (3, 8):
+    from typing_extensions import Protocol
+else:
+    from typing import Protocol
 
 Self = TypeVar("Self", bound="Scalar")
 

--- a/src/vector/protocols/lorentz.py
+++ b/src/vector/protocols/lorentz.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from __future__ import annotations  # type: ignore
 
 from typing import Protocol, Tuple, TypeVar, overload

--- a/src/vector/single/__init__.py
+++ b/src/vector/single/__init__.py
@@ -1,7 +1,4 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2019-2020, Jonas Eschle, Jim Pivarski, Eduardo Rodrigues, and Henry Schreiner.
 #
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
-
-from __future__ import absolute_import, division, print_function

--- a/src/vector/single/lorentz/__init__.py
+++ b/src/vector/single/lorentz/__init__.py
@@ -1,7 +1,4 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2019-2020, Jonas Eschle, Jim Pivarski, Eduardo Rodrigues, and Henry Schreiner.
 #
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
-
-from __future__ import absolute_import, division, print_function

--- a/src/vector/single/lorentz/xyzt.py
+++ b/src/vector/single/lorentz/xyzt.py
@@ -1,10 +1,8 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2019-2020, Jonas Eschle, Jim Pivarski, Eduardo Rodrigues, and Henry Schreiner.
 #
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-from __future__ import absolute_import, division, print_function
 
 import json
 from typing import TYPE_CHECKING, cast

--- a/src/vector/single/lorentz/xyzt.py
+++ b/src/vector/single/lorentz/xyzt.py
@@ -14,21 +14,18 @@ class LorentzXYZTFree(
     vector.mixins.lorentz.xyzt.LorentzXYZTMethodMixin,
     vector.mixins.lorentz.xyzt.LorentzXYZTDunderMixin,
 ):
-    def __init__(self, x, y, z, t):
-        # type: (float, float, float, float) -> None
+    def __init__(self, x: float, y: float, z: float, t: float) -> None:
         self.x = x
         self.y = y
         self.z = z
         self.t = t
 
-    def __repr__(self):
-        # type: () -> str
+    def __repr__(self) -> str:
         return "Lxyz({:.3g} {:.3g} {:.3g} {:.3g})".format(
             self.x, self.y, self.z, self.t
         )
 
-    def __getitem__(self, attr):
-        # type: (str) -> float
+    def __getitem__(self, attr: str) -> float:
         # It has to behave the same way as the bound objects or users will get confused.
         if attr in ("x", "y", "z", "t"):
             return getattr(self, attr)
@@ -45,4 +42,4 @@ class LorentzXYZTFree(
 if TYPE_CHECKING:
     from vector.protocols.lorentz import LorentzVector
 
-    _ = cast(LorentzXYZTFree, None)  # type: LorentzVector
+    _: LorentzVector = cast(LorentzXYZTFree, None)

--- a/tests/awkward_tests/__init__.py
+++ b/tests/awkward_tests/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import pytest
 
 pytest.importorskip("awkward")

--- a/tests/awkward_tests/test_demo.py
+++ b/tests/awkward_tests/test_demo.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
-
 import awkward as ak
 from pytest import approx
 

--- a/tests/awkward_tests/test_numba_basic.py
+++ b/tests/awkward_tests/test_numba_basic.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import awkward as ak
 import pytest
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import pytest
 
 import vector.single.lorentz.xyzt

--- a/tests/numba_tests/__init__.py
+++ b/tests/numba_tests/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import pytest
 
 pytest.importorskip("numba")

--- a/tests/numba_tests/test_awkward.py
+++ b/tests/numba_tests/test_awkward.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import numba
 import pytest
 

--- a/tests/numba_tests/test_basic.py
+++ b/tests/numba_tests/test_basic.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import numba
 from pytest import approx
 

--- a/tests/root_tests/__init__.py
+++ b/tests/root_tests/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import pytest
 
 pytest.importorskip("ROOT")

--- a/tests/root_tests/test_root_basic.py
+++ b/tests/root_tests/test_root_basic.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import ROOT
 from pytest import approx
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import vector
 import vector.single.lorentz.xyzt
 

--- a/tests/test_simple_param.py
+++ b/tests/test_simple_param.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from collections import namedtuple
 
 import numpy as np


### PR DESCRIPTION
Closes #27.

- chore: drop Python 2 (mostly via pyupgrade)
- chore: dropping Python 2 style type comments
