### PR TITLE
feat: allow overriding of protocol methods in subclasses

### DIFF
--- a/src/vector/_methods.py
+++ b/src/vector/_methods.py
@@ -2535,16 +2535,14 @@ _handler_priority = [
 
 
 def _get_handler_index(obj: VectorProtocol) -> int:
-    """
-    Returns the index of the first valid handler checking the list of parent classes
-    Returns -1 if no handler is found
-    """
+    """Returns the index of the first valid handler checking the list of parent classes"""
     index = -1
     for cls in type(obj).__mro__:
         with suppress(ValueError):
             index = _handler_priority.index(cls.__module__)
             break
 
+    assert index != -1
     return index
 
 

--- a/src/vector/_methods.py
+++ b/src/vector/_methods.py
@@ -2559,11 +2559,12 @@ def _handler_of(*objects: VectorProtocol) -> VectorProtocol:
     """
     handler = None
     for obj in objects:
-        if isinstance(obj, Vector):
-            if handler is None:
-                handler = obj
-            elif _get_handler_index(obj) > _get_handler_index(handler):
-                handler = obj
+        if not isinstance(obj, Vector):
+            continue
+        if handler is None:
+            handler = obj
+        elif _get_handler_index(obj) > _get_handler_index(handler):
+            handler = obj
 
     assert handler is not None
     return handler

--- a/src/vector/_methods.py
+++ b/src/vector/_methods.py
@@ -2539,7 +2539,9 @@ def _get_handler_index(obj: VectorProtocol) -> int:
     for cls in type(obj).__mro__:
         with suppress(ValueError):
             return _handler_priority.index(cls.__module__)
-    raise AssertionError(f"Could not find a valid handler for {obj}! This should not happen.")
+    raise AssertionError(
+        f"Could not find a valid handler for {obj}! This should not happen."
+    )
 
 
 def _handler_of(*objects: VectorProtocol) -> VectorProtocol:

--- a/src/vector/_methods.py
+++ b/src/vector/_methods.py
@@ -2536,14 +2536,10 @@ _handler_priority = [
 
 def _get_handler_index(obj: VectorProtocol) -> int:
     """Returns the index of the first valid handler checking the list of parent classes"""
-    index = -1
     for cls in type(obj).__mro__:
         with suppress(ValueError):
-            index = _handler_priority.index(cls.__module__)
-            break
-
-    assert index != -1
-    return index
+            return _handler_priority.index(cls.__module__)
+    raise AssertionError(f"Could not find a valid handler for {obj}! This should not happen.")
 
 
 def _handler_of(*objects: VectorProtocol) -> VectorProtocol:

--- a/src/vector/_methods.py
+++ b/src/vector/_methods.py
@@ -4,8 +4,8 @@
 # or https://github.com/scikit-hep/vector for details.
 
 import typing
-
 from contextlib import suppress
+
 from vector._typeutils import (
     BoolCollection,
     ScalarCollection,

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -1,0 +1,17 @@
+# Copyright (c) 2019-2021, Jonas Eschle, Jim Pivarski, Eduardo Rodrigues, and Henry Schreiner.
+#
+# Distributed under the 3-clause BSD license, see accompanying file LICENSE
+# or https://github.com/scikit-hep/vector for details.
+
+import vector
+
+
+class CustomVector(vector.VectorObject4D):
+    pass
+
+
+def test_handler_of():
+    object_a = CustomVector.from_xyzt(0.0, 0.0, 0.0, 0.0)
+    object_b = CustomVector.from_xyzt(1.0, 1.0, 1.0, 1.0)
+    protocol = vector._methods._handler_of(object_a, object_b)
+    assert protocol == object_a


### PR DESCRIPTION
This PR addresses issue https://github.com/scikit-hep/vector/issues/127 by extending the [_handler_of](https://github.com/scikit-hep/vector/blob/5ba111555bae20887e417c1e73101a940d06fc57/src/vector/_methods.py#L2536-L2556) function to consider the module of all the inherited classes of a certain object. This is neccesary to allow the definition of client-side custom classes that can inherit from the library ones, and override their protocol methods (`__iadd__`, `__isub__` ...).

### Additional clarifications
- I inverted the logic of the `if isinstance(obj, Vector)` to reduce indentation.
- I imported Python's `contextlib.suppress` helper to reduce indentation.

cc @jpivarski 