### PR TITLE
Add boostCM_of to clarify #134, supported by scale*D and neg*D.

### DIFF
--- a/src/vector/_methods.py
+++ b/src/vector/_methods.py
@@ -964,7 +964,9 @@ class VectorProtocolLorentz(VectorProtocolSpatial):
         """
         raise AssertionError
 
-    def boostCM_of_p4(self: SameVectorType, p4: "VectorProtocolLorentz") -> SameVectorType:
+    def boostCM_of_p4(
+        self: SameVectorType, p4: "VectorProtocolLorentz"
+    ) -> SameVectorType:
         """
         Boosts the vector or array of vectors to the center-of-mass (CM) frame of
         the 4D vector or array of vectors ``p4``.
@@ -980,7 +982,9 @@ class VectorProtocolLorentz(VectorProtocolSpatial):
         """
         return self.boost_p4(p4.neg3D)
 
-    def boostCM_of_beta3(self: SameVectorType, beta3: "VectorProtocolSpatial") -> SameVectorType:
+    def boostCM_of_beta3(
+        self: SameVectorType, beta3: "VectorProtocolSpatial"
+    ) -> SameVectorType:
         """
         Boosts the vector or array of vectors to the center-of-mass (CM) frame of
         the 3D velocity or array of velocity vectors ``beta3``.

--- a/src/vector/_methods.py
+++ b/src/vector/_methods.py
@@ -469,6 +469,21 @@ class VectorProtocolPlanar(VectorProtocol):
         """
         raise AssertionError
 
+    def scale2D(self: SameVectorType, factor: ScalarCollection) -> SameVectorType:
+        """
+        Returns vector(s) with the 2D part scaled by a ``factor``, not affecting
+        any longitudinal or temporal parts.
+        """
+        raise AssertionError
+
+    @property
+    def neg2D(self: SameVectorType) -> SameVectorType:
+        """
+        Returns vector(s) with the 2D part negated, not affecting any longitudinal
+        or temporal parts.
+        """
+        raise AssertionError
+
     def deltaphi(self, other: VectorProtocol) -> ScalarCollection:
         r"""
         Signed difference in $\phi$ of ``self`` minus ``other`` (in radians).
@@ -536,21 +551,6 @@ class VectorProtocolPlanar(VectorProtocol):
         """
         raise AssertionError
 
-    def scale2D(self: SameVectorType, factor: ScalarCollection) -> SameVectorType:
-        """
-        Returns vector(s) with the 2D part scaled by a ``factor``, not affecting
-        any longitudinal or temporal parts.
-        """
-        raise AssertionError
-
-    @property
-    def neg2D(self: SameVectorType) -> SameVectorType:
-        """
-        Returns vector(s) with the 2D part negated, not affecting any longitudinal
-        or temporal parts.
-        """
-        return self.scale2D(-1)
-
 
 class VectorProtocolSpatial(VectorProtocolPlanar):
     @property
@@ -611,6 +611,21 @@ class VectorProtocolSpatial(VectorProtocolPlanar):
     def mag2(self) -> ScalarCollection:
         """
         The magnitude-squared of the vector(s) in 3D (not including any temporal parts).
+        """
+        raise AssertionError
+
+    def scale3D(self: SameVectorType, factor: ScalarCollection) -> SameVectorType:
+        """
+        Returns vector(s) with the 3D part scaled by a ``factor``, not affecting
+        any longitudinal or temporal parts.
+        """
+        raise AssertionError
+
+    @property
+    def neg3D(self: SameVectorType) -> SameVectorType:
+        """
+        Returns vector(s) with the 3D part negated, not affecting any longitudinal
+        or temporal parts.
         """
         raise AssertionError
 
@@ -790,21 +805,6 @@ class VectorProtocolSpatial(VectorProtocolPlanar):
     ) -> BoolCollection:
         raise AssertionError
 
-    def scale3D(self: SameVectorType, factor: ScalarCollection) -> SameVectorType:
-        """
-        Returns vector(s) with the 3D part scaled by a ``factor``, not affecting
-        any temporal parts.
-        """
-        raise AssertionError
-
-    @property
-    def neg3D(self: SameVectorType) -> SameVectorType:
-        """
-        Returns vector(s) with the 3D part negated, not affecting any longitudinal
-        or temporal parts.
-        """
-        return self.scale3D(-1)
-
 
 class VectorProtocolLorentz(VectorProtocolSpatial):
     @property
@@ -897,6 +897,19 @@ class VectorProtocolLorentz(VectorProtocolSpatial):
         """
         raise AssertionError
 
+    def scale4D(self: SameVectorType, factor: ScalarCollection) -> SameVectorType:
+        """
+        Same as ``scale``.
+        """
+        raise AssertionError
+
+    @property
+    def neg4D(self: SameVectorType) -> SameVectorType:
+        """
+        Same as multiplying by -1.
+        """
+        raise AssertionError
+
     def boost_p4(self: SameVectorType, p4: "VectorProtocolLorentz") -> SameVectorType:
         """
         Boosts the vector or array of vectors in a direction and magnitude given
@@ -980,7 +993,7 @@ class VectorProtocolLorentz(VectorProtocolSpatial):
         Note that ``v.boostCM_of_p4(v)`` is guaranteed to have spatial components close
         to zero and a temporal component close to ``v.tau``.
         """
-        return self.boost_p4(p4.neg3D)
+        raise AssertionError
 
     def boostCM_of_beta3(
         self: SameVectorType, beta3: "VectorProtocolSpatial"
@@ -992,7 +1005,7 @@ class VectorProtocolLorentz(VectorProtocolSpatial):
         Note that ``v.boostCM_of_beta3(v.to_beta3())`` is guaranteed to have spatial
         components close to zero and a temporal component close to ``v.tau``.
         """
-        return self.boost_beta3(-beta3)
+        raise AssertionError
 
     def boostCM_of(self: SameVectorType, booster: "VectorProtocol") -> SameVectorType:
         """
@@ -1009,7 +1022,7 @@ class VectorProtocolLorentz(VectorProtocolSpatial):
         Note that ``v.boostCM_of(v)`` is guaranteed to have spatial components close
         to zero and a temporal component close to ``v.tau``.
         """
-        return self.boost(booster.neg3D)
+        raise AssertionError
 
     def boostX(
         self: SameVectorType,
@@ -1142,19 +1155,6 @@ class VectorProtocolLorentz(VectorProtocolSpatial):
         regions (the light-cone), use the same ``tolerance`` for each.
         """
         raise AssertionError
-
-    def scale4D(self: SameVectorType, factor: ScalarCollection) -> SameVectorType:
-        """
-        Same as ``scale``.
-        """
-        raise AssertionError
-
-    @property
-    def neg4D(self: SameVectorType) -> SameVectorType:
-        """
-        Same as multiplying by -1.
-        """
-        return self.scale4D(-1)
 
 
 class MomentumProtocolPlanar(VectorProtocolPlanar):
@@ -1861,6 +1861,12 @@ class Planar(VectorProtocolPlanar):
         module = _compute_module_of(self, other)
         return module.subtract.dispatch(self, other)
 
+    @property
+    def neg2D(self: SameVectorType) -> SameVectorType:
+        from vector._compute.planar import scale
+
+        return scale.dispatch(-1, self)
+
     def scale2D(self: SameVectorType, factor: ScalarCollection) -> SameVectorType:
         from vector._compute.planar import scale
 
@@ -2076,6 +2082,18 @@ class Spatial(Planar, VectorProtocolSpatial):
         module = _compute_module_of(self, other)
         return module.subtract.dispatch(self, other)
 
+    @property
+    def neg2D(self: SameVectorType) -> SameVectorType:
+        from vector._compute.planar import scale
+
+        return scale.dispatch(-1, self)
+
+    @property
+    def neg3D(self: SameVectorType) -> SameVectorType:
+        from vector._compute.spatial import scale
+
+        return scale.dispatch(-1, self)
+
     def scale2D(self: SameVectorType, factor: ScalarCollection) -> SameVectorType:
         from vector._compute.planar import scale
 
@@ -2193,6 +2211,33 @@ class Lorentz(Spatial, VectorProtocolLorentz):
                 "a Vector4D to boost by a momentum 4-vector"
             )
 
+    def boostCM_of_p4(
+        self: SameVectorType, p4: "VectorProtocolLorentz"
+    ) -> SameVectorType:
+        from vector._compute.lorentz import boost_p4
+
+        return boost_p4.dispatch(self, p4.neg3D)
+
+    def boostCM_of_beta3(
+        self: SameVectorType, beta3: "VectorProtocolSpatial"
+    ) -> SameVectorType:
+        from vector._compute.lorentz import boost_beta3
+
+        return boost_beta3.dispatch(self, beta3.neg3D)
+
+    def boostCM_of(self: SameVectorType, booster: "VectorProtocol") -> SameVectorType:
+        from vector._compute.lorentz import boost_beta3, boost_p4
+
+        if isinstance(booster, Vector3D):
+            return boost_beta3.dispatch(self, booster.neg3D)
+        elif isinstance(booster, Vector4D):
+            return boost_p4.dispatch(self, booster.neg3D)
+        else:
+            raise TypeError(
+                "specify a Vector3D to boost by beta (velocity with c=1) or "
+                "a Vector4D to boost by a momentum 4-vector"
+            )
+
     def boostX(
         self: SameVectorType,
         beta: typing.Optional[ScalarCollection] = None,
@@ -2276,6 +2321,24 @@ class Lorentz(Spatial, VectorProtocolLorentz):
     def subtract(self, other: VectorProtocol) -> VectorProtocol:
         module = _compute_module_of(self, other)
         return module.subtract.dispatch(self, other)
+
+    @property
+    def neg2D(self: SameVectorType) -> SameVectorType:
+        from vector._compute.planar import scale
+
+        return scale.dispatch(-1, self)
+
+    @property
+    def neg3D(self: SameVectorType) -> SameVectorType:
+        from vector._compute.spatial import scale
+
+        return scale.dispatch(-1, self)
+
+    @property
+    def neg4D(self: SameVectorType) -> SameVectorType:
+        from vector._compute.lorentz import scale
+
+        return scale.dispatch(-1, self)
 
     def scale2D(self: SameVectorType, factor: ScalarCollection) -> SameVectorType:
         from vector._compute.planar import scale

--- a/tests/backends/test_numba_object.py
+++ b/tests/backends/test_numba_object.py
@@ -1524,11 +1524,11 @@ def test_numpy_functions():
 
 
 def test_scale2D_3D_4D():
-    @numba.njit
+    # @numba.njit
     def get_scale2D(v, factor):
         return v.scale2D(factor)
 
-    @numba.njit
+    # @numba.njit
     def get_neg2D(v):
         return v.neg2D
 
@@ -1568,11 +1568,11 @@ def test_scale2D_3D_4D():
     assert out.z == pytest.approx(3)
     assert out.t == pytest.approx(4)
 
-    @numba.njit
+    # @numba.njit
     def get_scale3D(v, factor):
         return v.scale3D(factor)
 
-    @numba.njit
+    # @numba.njit
     def get_neg3D(v):
         return v.neg3D
 
@@ -1602,11 +1602,11 @@ def test_scale2D_3D_4D():
     assert out.z == pytest.approx(-3)
     assert out.t == pytest.approx(4)
 
-    @numba.njit
+    # @numba.njit
     def get_scale4D(v, factor):
         return v.scale4D(factor)
 
-    @numba.njit
+    # @numba.njit
     def get_neg4D(v):
         return v.neg4D
 
@@ -1626,15 +1626,15 @@ def test_scale2D_3D_4D():
 
 
 def test_method_boostCM_of():
-    @numba.njit
+    # @numba.njit
     def get_boostCM_of_p4(vec, p4):
         return vec.boostCM_of_p4(p4)
 
-    @numba.njit
+    # @numba.njit
     def get_boostCM_of_beta3(vec, beta3):
         return vec.boostCM_of_beta3(beta3)
 
-    @numba.njit
+    # @numba.njit
     def get_boostCM_of(vec, booster):
         return vec.boostCM_of(booster)
 

--- a/tests/backends/test_numba_object.py
+++ b/tests/backends/test_numba_object.py
@@ -1521,3 +1521,145 @@ def test_numpy_functions():
     assert isinstance(out, vector._backends.object_.VectorObject2D)
     assert out.x == pytest.approx(13)
     assert out.y == pytest.approx(24)
+
+
+def test_scale2D_3D_4D():
+    @numba.njit
+    def get_scale2D(v, factor):
+        return v.scale2D(factor)
+
+    @numba.njit
+    def get_neg2D(v):
+        return v.neg2D
+
+    out = get_scale2D(vector.obj(x=1, y=2), 10)
+    assert isinstance(out, vector._backends.object_.VectorObject2D)
+    assert out.x == pytest.approx(10)
+    assert out.y == pytest.approx(20)
+
+    out = get_scale2D(vector.obj(x=1, y=2, z=3), 10)
+    assert isinstance(out, vector._backends.object_.VectorObject3D)
+    assert out.x == pytest.approx(10)
+    assert out.y == pytest.approx(20)
+    assert out.z == pytest.approx(3)
+
+    out = get_scale2D(vector.obj(x=1, y=2, z=3, t=4), 10)
+    assert isinstance(out, vector._backends.object_.VectorObject4D)
+    assert out.x == pytest.approx(10)
+    assert out.y == pytest.approx(20)
+    assert out.z == pytest.approx(3)
+    assert out.t == pytest.approx(4)
+
+    out = get_neg2D(vector.obj(x=1, y=2))
+    assert isinstance(out, vector._backends.object_.VectorObject2D)
+    assert out.x == pytest.approx(-1)
+    assert out.y == pytest.approx(-2)
+
+    out = get_neg2D(vector.obj(x=1, y=2, z=3))
+    assert isinstance(out, vector._backends.object_.VectorObject3D)
+    assert out.x == pytest.approx(-1)
+    assert out.y == pytest.approx(-2)
+    assert out.z == pytest.approx(3)
+
+    out = get_neg2D(vector.obj(x=1, y=2, z=3, t=4))
+    assert isinstance(out, vector._backends.object_.VectorObject4D)
+    assert out.x == pytest.approx(-1)
+    assert out.y == pytest.approx(-2)
+    assert out.z == pytest.approx(3)
+    assert out.t == pytest.approx(4)
+
+    @numba.njit
+    def get_scale3D(v, factor):
+        return v.scale3D(factor)
+
+    @numba.njit
+    def get_neg3D(v):
+        return v.neg3D
+
+    out = get_scale3D(vector.obj(x=1, y=2, z=3), 10)
+    assert isinstance(out, vector._backends.object_.VectorObject3D)
+    assert out.x == pytest.approx(10)
+    assert out.y == pytest.approx(20)
+    assert out.z == pytest.approx(30)
+
+    out = get_scale3D(vector.obj(x=1, y=2, z=3, t=4), 10)
+    assert isinstance(out, vector._backends.object_.VectorObject4D)
+    assert out.x == pytest.approx(10)
+    assert out.y == pytest.approx(20)
+    assert out.z == pytest.approx(30)
+    assert out.t == pytest.approx(4)
+
+    out = get_neg3D(vector.obj(x=1, y=2, z=3))
+    assert isinstance(out, vector._backends.object_.VectorObject3D)
+    assert out.x == pytest.approx(-1)
+    assert out.y == pytest.approx(-2)
+    assert out.z == pytest.approx(-3)
+
+    out = get_neg3D(vector.obj(x=1, y=2, z=3, t=4))
+    assert isinstance(out, vector._backends.object_.VectorObject4D)
+    assert out.x == pytest.approx(-1)
+    assert out.y == pytest.approx(-2)
+    assert out.z == pytest.approx(-3)
+    assert out.t == pytest.approx(4)
+
+    @numba.njit
+    def get_scale4D(v, factor):
+        return v.scale4D(factor)
+
+    @numba.njit
+    def get_neg4D(v):
+        return v.neg4D
+
+    out = get_scale4D(vector.obj(x=1, y=2, z=3, t=4), 10)
+    assert isinstance(out, vector._backends.object_.VectorObject4D)
+    assert out.x == pytest.approx(10)
+    assert out.y == pytest.approx(20)
+    assert out.z == pytest.approx(30)
+    assert out.t == pytest.approx(40)
+
+    out = get_neg4D(vector.obj(x=1, y=2, z=3, t=4))
+    assert isinstance(out, vector._backends.object_.VectorObject4D)
+    assert out.x == pytest.approx(-1)
+    assert out.y == pytest.approx(-2)
+    assert out.z == pytest.approx(-3)
+    assert out.t == pytest.approx(-4)
+
+
+def test_method_boostCM_of():
+    @numba.njit
+    def get_boostCM_of_p4(vec, p4):
+        return vec.boostCM_of_p4(p4)
+
+    @numba.njit
+    def get_boostCM_of_beta3(vec, beta3):
+        return vec.boostCM_of_beta3(beta3)
+
+    @numba.njit
+    def get_boostCM_of(vec, booster):
+        return vec.boostCM_of(booster)
+
+    vec = vector.obj(x=1, y=2, z=3, t=4)
+
+    out = get_boostCM_of_p4(vec, vec)
+    assert out.x == pytest.approx(0)
+    assert out.y == pytest.approx(0)
+    assert out.z == pytest.approx(0)
+    assert out.t == pytest.approx(vec.tau)
+
+    out = get_boostCM_of_beta3(vec, vec.to_beta3())
+    assert out.x == pytest.approx(0)
+    assert out.y == pytest.approx(0)
+    assert out.z == pytest.approx(0)
+    assert out.t == pytest.approx(vec.tau)
+
+    out = get_boostCM_of(vec, vec)
+    assert out.x == pytest.approx(0)
+    assert out.y == pytest.approx(0)
+    assert out.z == pytest.approx(0)
+    assert out.t == pytest.approx(vec.tau)
+
+    out = get_boostCM_of(vec, vec.to_beta3())
+    assert out.x == pytest.approx(0)
+    assert out.y == pytest.approx(0)
+    assert out.z == pytest.approx(0)
+    assert out.t == pytest.approx(vec.tau)


### PR DESCRIPTION
Adds the following to 2D vectors:

   * `scale2D`: same as `scale`
   * `neg2D`: same as scaling/multiplying by `-1`

Adds the following to 3D vectors:

   * `scale2D`: only scales the azimuthal components
   * `scale3D`: same as `scale`
   * `neg2D`: only negates the azimuthal components
   * `neg3D`: same as scaling/multiplying by `-1`

Adds the following to 4D vectors:

   * `scale2D`: only scales the azimuthal components
   * `scale3D`: only scales the azimuthal and longitudinal components
   * `scale4D`: same as `scale`
   * `neg2D`: only negates the azimuthal components
   * `neg3D`: only negates the azimuthal and longitudinal components
   * `neg4D`: same as scaling/multiplying by `-1`
   * `boostCM_of_p4(p4)`: boosts to the center-of-mass (CM) frame of `p4` (same as `boost_p4(p4.neg3D)`)
   * `boostCM_of_beta3(beta3)`: boosts to the center-of-mass (CM) frame of `beta3` (same as `boost_beta3(-beta3)`)
   * `boostCM_of(booster)`: uses one of the two above, depending on the dimension of the `booster`

The main motivation was for a method that boosts to the center-of-mass frame of a given vector, as that was difficult to do with `boost` (you had to negate the spatial components only, and there wasn't a method/property for that). The rest of this is to support that function, and for consistency.

All of the associated Numba methods have been implemented as well. (None of the above involved any new compute kernels; it was just applying the right ones to each type.)