### PR TITLE
VectorNumpy pickle suppport to enable multiprocessing

### DIFF
--- a/src/vector/_backends/numpy_.py
+++ b/src/vector/_backends/numpy_.py
@@ -431,13 +431,13 @@ class VectorNumpy(Vector, GetItem):
         return numpy.not_equal(self, other)  # type: ignore
 
     def __reduce__(self):
-        pickled_state = super(VectorNumpy, self).__reduce__()
+        pickled_state = super().__reduce__()
         new_state = pickled_state[2] + (self.__dict__,)
         return (pickled_state[0], pickled_state[1], new_state)
 
     def __setstate__(self, state):
         self.__dict__.update(state[-1])
-        super(VectorNumpy, self).__setstate__(state[0:-1])
+        super().__setstate__(state[0:-1])
 
     def __array_ufunc__(
         self,

--- a/src/vector/_backends/numpy_.py
+++ b/src/vector/_backends/numpy_.py
@@ -430,6 +430,15 @@ class VectorNumpy(Vector, GetItem):
     def __ne__(self, other: typing.Any) -> typing.Any:
         return numpy.not_equal(self, other)  # type: ignore
 
+    def __reduce__(self):
+        pickled_state = super(VectorNumpy, self).__reduce__()
+        new_state = pickled_state[2] + (self.__dict__,)
+        return (pickled_state[0], pickled_state[1], new_state)
+
+    def __setstate__(self, state):
+        self.__dict__.update(state[-1])
+        super(VectorNumpy, self).__setstate__(state[0:-1])
+
     def __array_ufunc__(
         self,
         ufunc: typing.Any,
@@ -665,6 +674,9 @@ class VectorNumpy2D(VectorNumpy, Planar, Vector2D, numpy.ndarray):  # type: igno
         return array.view(cls)
 
     def __array_finalize__(self, obj: typing.Any) -> None:
+        if obj is None:
+            return
+
         if _has(self, ("x", "y")):
             self._azimuthal_type = AzimuthalNumpyXY
         elif _has(self, ("rho", "phi")):
@@ -840,6 +852,9 @@ class MomentumNumpy2D(PlanarMomentum, VectorNumpy2D):  # type: ignore
     dtype: "numpy.dtype[typing.Any]"
 
     def __array_finalize__(self, obj: typing.Any) -> None:
+        if obj is None:
+            return
+
         self.dtype.names = tuple(
             _repr_momentum_to_generic.get(x, x) for x in (self.dtype.names or ())
         )
@@ -882,6 +897,9 @@ class VectorNumpy3D(VectorNumpy, Spatial, Vector3D, numpy.ndarray):  # type: ign
         return array.view(cls)
 
     def __array_finalize__(self, obj: typing.Any) -> None:
+        if obj is None:
+            return
+
         if _has(self, ("x", "y")):
             self._azimuthal_type = AzimuthalNumpyXY
         elif _has(self, ("rho", "phi")):
@@ -1076,6 +1094,9 @@ class MomentumNumpy3D(SpatialMomentum, VectorNumpy3D):  # type: ignore
     dtype: "numpy.dtype[typing.Any]"
 
     def __array_finalize__(self, obj: typing.Any) -> None:
+        if obj is None:
+            return
+
         self.dtype.names = tuple(
             _repr_momentum_to_generic.get(x, x) for x in (self.dtype.names or ())
         )
@@ -1132,6 +1153,9 @@ class VectorNumpy4D(VectorNumpy, Lorentz, Vector4D, numpy.ndarray):  # type: ign
         return array.view(cls)
 
     def __array_finalize__(self, obj: typing.Any) -> None:
+        if obj is None:
+            return
+
         if _has(self, ("x", "y")):
             self._azimuthal_type = AzimuthalNumpyXY
         elif _has(self, ("rho", "phi")):
@@ -1349,6 +1373,9 @@ class MomentumNumpy4D(LorentzMomentum, VectorNumpy4D):  # type: ignore
     dtype: "numpy.dtype[typing.Any]"
 
     def __array_finalize__(self, obj: typing.Any) -> None:
+        if obj is None:
+            return
+
         self.dtype.names = tuple(
             _repr_momentum_to_generic.get(x, x) for x in (self.dtype.names or ())
         )

--- a/src/vector/_backends/numpy_.py
+++ b/src/vector/_backends/numpy_.py
@@ -430,12 +430,12 @@ class VectorNumpy(Vector, GetItem):
     def __ne__(self, other: typing.Any) -> typing.Any:
         return numpy.not_equal(self, other)  # type: ignore
 
-    def __reduce__(self) -> typing.Sequence[typing.Any]:
+    def __reduce__(self) -> typing.Union[str, typing.Tuple[typing.Any, ...]]:
         pickled_state = super().__reduce__()
         new_state = (*pickled_state[2], self.__dict__)
         return pickled_state[0], pickled_state[1], new_state
 
-    def __setstate__(self, state: typing.Sequence[typing.Any]) -> None:
+    def __setstate__(self, state: typing.Any) -> None:
         self.__dict__.update(state[-1])
         super().__setstate__(state[0:-1])  # type: ignore
 

--- a/src/vector/_backends/numpy_.py
+++ b/src/vector/_backends/numpy_.py
@@ -430,12 +430,12 @@ class VectorNumpy(Vector, GetItem):
     def __ne__(self, other: typing.Any) -> typing.Any:
         return numpy.not_equal(self, other)  # type: ignore
 
-    def __reduce__(self) -> typing.Any:
+    def __reduce__(self) -> typing.Sequence[typing.Any]:
         pickled_state = super().__reduce__()
         new_state = (*pickled_state[2], self.__dict__)
         return pickled_state[0], pickled_state[1], new_state
 
-    def __setstate__(self, state) -> None:
+    def __setstate__(self, state: typing.Sequence[typing.Any]) -> None:
         self.__dict__.update(state[-1])
         super().__setstate__(state[0:-1])  # type: ignore
 

--- a/src/vector/_backends/numpy_.py
+++ b/src/vector/_backends/numpy_.py
@@ -430,14 +430,14 @@ class VectorNumpy(Vector, GetItem):
     def __ne__(self, other: typing.Any) -> typing.Any:
         return numpy.not_equal(self, other)  # type: ignore
 
-    def __reduce__(self):
+    def __reduce__(self) -> typing.Any:
         pickled_state = super().__reduce__()
-        new_state = pickled_state[2] + (self.__dict__,)
-        return (pickled_state[0], pickled_state[1], new_state)
+        new_state = (*pickled_state[2], self.__dict__)
+        return pickled_state[0], pickled_state[1], new_state
 
-    def __setstate__(self, state):
+    def __setstate__(self, state) -> None:
         self.__dict__.update(state[-1])
-        super().__setstate__(state[0:-1])
+        super().__setstate__(state[0:-1])  # type: ignore
 
     def __array_ufunc__(
         self,

--- a/tests/backends/test_numpy.py
+++ b/tests/backends/test_numpy.py
@@ -4,6 +4,7 @@
 # or https://github.com/scikit-hep/vector for details.
 
 import math
+import pickle
 
 import numpy
 
@@ -29,3 +30,43 @@ def test_rhophi():
     assert numpy.allclose(array.y, [0, 1, 4])
     assert numpy.allclose(array.rho, [0, 1, 5])
     assert numpy.allclose(array.phi, [10, math.atan2(1, 0), math.atan2(4, 3)])
+
+
+def test_pickle_vector_numpy_2d():
+    array = vector._backends.numpy_.VectorNumpy2D(
+        [(0, 0), (0, 1), (3, 4)], dtype=[("x", numpy.float64), ("y", numpy.float64)]
+    )
+
+    array_pickled = pickle.dumps(array)
+    array_new = pickle.loads(array_pickled)
+
+    assert numpy.allclose(array_new.x, array.x)
+    assert numpy.allclose(array_new.y, array.y)
+
+
+def test_pickle_vector_numpy_3d():
+    array = vector._backends.numpy_.VectorNumpy3D(
+        [(0, 0, 0), (0, 1, 1), (3, 4, 5)], dtype=[("x", numpy.float64), ("y", numpy.float64), ("z", numpy.float64)]
+    )
+
+    array_pickled = pickle.dumps(array)
+    array_new = pickle.loads(array_pickled)
+
+    assert numpy.allclose(array_new.x, array.x)
+    assert numpy.allclose(array_new.y, array.y)
+    assert numpy.allclose(array_new.z, array.z)
+
+
+def test_pickle_vector_numpy_4d():
+    array = vector._backends.numpy_.VectorNumpy4D(
+        [(0, 0, 0, 0), (0, 1, 1, 1), (3, 4, 5, 6)],
+        dtype=[("x", numpy.float64), ("y", numpy.float64), ("z", numpy.float64), ("t", numpy.float64)]
+    )
+
+    array_pickled = pickle.dumps(array)
+    array_new = pickle.loads(array_pickled)
+
+    assert numpy.allclose(array_new.x, array.x)
+    assert numpy.allclose(array_new.y, array.y)
+    assert numpy.allclose(array_new.z, array.z)
+    assert numpy.allclose(array_new.t, array.t)

--- a/tests/backends/test_numpy.py
+++ b/tests/backends/test_numpy.py
@@ -58,7 +58,8 @@ def test_pickle_momentum_numpy_2d():
 
 def test_pickle_vector_numpy_3d():
     array = vector._backends.numpy_.VectorNumpy3D(
-        [(0, 0, 0), (0, 1, 1), (3, 4, 5)], dtype=[("x", numpy.float64), ("y", numpy.float64), ("z", numpy.float64)]
+        [(0, 0, 0), (0, 1, 1), (3, 4, 5)],
+        dtype=[("x", numpy.float64), ("y", numpy.float64), ("z", numpy.float64)],
     )
 
     array_pickled = pickle.dumps(array)
@@ -72,7 +73,11 @@ def test_pickle_vector_numpy_3d():
 def test_pickle_momentum_numpy_3d():
     array = vector._backends.numpy_.MomentumNumpy3D(
         [(0, 0, 0), (0, 1, 1), (3, 4, 5)],
-        dtype=[("rho", numpy.float64), ("phi", numpy.float64), ("theta", numpy.float64)]
+        dtype=[
+            ("rho", numpy.float64),
+            ("phi", numpy.float64),
+            ("theta", numpy.float64),
+        ],
     )
 
     array_pickled = pickle.dumps(array)
@@ -86,7 +91,12 @@ def test_pickle_momentum_numpy_3d():
 def test_pickle_vector_numpy_4d():
     array = vector._backends.numpy_.VectorNumpy4D(
         [(0, 0, 0, 0), (0, 1, 1, 1), (3, 4, 5, 6)],
-        dtype=[("x", numpy.float64), ("y", numpy.float64), ("z", numpy.float64), ("t", numpy.float64)]
+        dtype=[
+            ("x", numpy.float64),
+            ("y", numpy.float64),
+            ("z", numpy.float64),
+            ("t", numpy.float64),
+        ],
     )
 
     array_pickled = pickle.dumps(array)
@@ -101,7 +111,12 @@ def test_pickle_vector_numpy_4d():
 def test_pickle_momentum_numpy_4d():
     array = vector._backends.numpy_.MomentumNumpy4D(
         [(0, 0, 0, 0), (0, 1, 1, 1), (3, 4, 5, 6)],
-        dtype=[("rho", numpy.float64), ("phi", numpy.float64), ("theta", numpy.float64), ("tau", numpy.float64)]
+        dtype=[
+            ("rho", numpy.float64),
+            ("phi", numpy.float64),
+            ("theta", numpy.float64),
+            ("tau", numpy.float64),
+        ],
     )
 
     array_pickled = pickle.dumps(array)

--- a/tests/backends/test_numpy.py
+++ b/tests/backends/test_numpy.py
@@ -44,6 +44,18 @@ def test_pickle_vector_numpy_2d():
     assert numpy.allclose(array_new.y, array.y)
 
 
+def test_pickle_momentum_numpy_2d():
+    array = vector._backends.numpy_.MomentumNumpy2D(
+        [(0, 0), (0, 1), (3, 4)], dtype=[("rho", numpy.float64), ("phi", numpy.float64)]
+    )
+
+    array_pickled = pickle.dumps(array)
+    array_new = pickle.loads(array_pickled)
+
+    assert numpy.allclose(array_new.rho, array.rho)
+    assert numpy.allclose(array_new.phi, array.phi)
+
+
 def test_pickle_vector_numpy_3d():
     array = vector._backends.numpy_.VectorNumpy3D(
         [(0, 0, 0), (0, 1, 1), (3, 4, 5)], dtype=[("x", numpy.float64), ("y", numpy.float64), ("z", numpy.float64)]
@@ -55,6 +67,20 @@ def test_pickle_vector_numpy_3d():
     assert numpy.allclose(array_new.x, array.x)
     assert numpy.allclose(array_new.y, array.y)
     assert numpy.allclose(array_new.z, array.z)
+
+
+def test_pickle_momentum_numpy_3d():
+    array = vector._backends.numpy_.MomentumNumpy3D(
+        [(0, 0, 0), (0, 1, 1), (3, 4, 5)],
+        dtype=[("rho", numpy.float64), ("phi", numpy.float64), ("theta", numpy.float64)]
+    )
+
+    array_pickled = pickle.dumps(array)
+    array_new = pickle.loads(array_pickled)
+
+    assert numpy.allclose(array_new.rho, array.rho)
+    assert numpy.allclose(array_new.phi, array.phi)
+    assert numpy.allclose(array_new.theta, array.theta)
 
 
 def test_pickle_vector_numpy_4d():
@@ -70,3 +96,18 @@ def test_pickle_vector_numpy_4d():
     assert numpy.allclose(array_new.y, array.y)
     assert numpy.allclose(array_new.z, array.z)
     assert numpy.allclose(array_new.t, array.t)
+
+
+def test_pickle_momentum_numpy_4d():
+    array = vector._backends.numpy_.MomentumNumpy4D(
+        [(0, 0, 0, 0), (0, 1, 1, 1), (3, 4, 5, 6)],
+        dtype=[("rho", numpy.float64), ("phi", numpy.float64), ("theta", numpy.float64), ("tau", numpy.float64)]
+    )
+
+    array_pickled = pickle.dumps(array)
+    array_new = pickle.loads(array_pickled)
+
+    assert numpy.allclose(array_new.rho, array.rho)
+    assert numpy.allclose(array_new.phi, array.phi)
+    assert numpy.allclose(array_new.theta, array.theta)
+    assert numpy.allclose(array_new.tau, array.tau)


### PR DESCRIPTION
When sharing `VectorNumpy` based arrays (like `VectorNumpy3D`) between processes in python, [pickle](https://docs.python.org/3/library/pickle.html) is used for serialisation and deserialisation of the objects. But it seems that structured arrays which inherhit form a Numpy array lose part of their state during that process.

Here is an example that shows the problem:

```python
import pickle
import numpy as np
import vector

test = np.arange(0, 24, 0.1).view([("x", float), ("y", float), ("z", float)]).view(vector.VectorNumpy3D)

test_pickled = pickle.dumps(test)
test_new = pickle.loads(test_pickled)

print(test_new) # Leads to exception A
print(test_new[0]) # Leads to exception B
```

#### Exception A
First, there is a problem that `__array_finalize__` is called twice from `pickle.loads`, once with the actual data and once with a None type. This leads to the following error message:

```python
VectorNumpy3D must have a structured dtype containing fields ("x", "y") or ("rho", "phi")
```

It is possible to prevent this behaviour by checking for `None` arguments and just ignore them ([L900-L901](https://github.com/cansik/vector/blob/numpy-pickle-support/src/vector/_backends/numpy_.py#L900-L901))

#### Exception B
After that it is possible to `print` the unpickled array, but accessing the elements itself (`test_new[0]`) leads to another error message. I guess it has to do with the construction of the VectorObjects itself.

```python
TypeError: __init__() takes 3 positional arguments but 4 were given
```

#### Solution
After a bit of research I found this [stackoverflow answer](https://stackoverflow.com/a/26599346/1138326), why subclasses of numpy can lose their state when being pickled. Implementing this in the `VectorNumpy` parent class ([L433-L440](https://github.com/cansik/vector/blob/numpy-pickle-support/src/vector/_backends/numpy_.py#L433-L440)) fixes it also for all subclasses like `VectorNumpy3D`. To check if the implementation works, there are six new tests pickling/unpickling every Vector/Momentum-Numpy array variant.

In my own projects the code is already used for multi-processed calculations and result-sharing in the `VectorNumpy4D` format. Would be great if you could review it and give me feedback if this implementation is ok.