### PR TITLE
fix: bump black to 22.3.0 due to click 8.1 release

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
     args: [--py36-plus]
 
 - repo: https://github.com/psf/black
-  rev: 22.1.0
+  rev: 22.3.0
   hooks:
   - id: black
 


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos