### PR TITLE
docs: fix intro notebook, and submodule and subpackage index

### DIFF
--- a/docs/api/vector._backends.rst
+++ b/docs/api/vector._backends.rst
@@ -5,7 +5,7 @@ Submodules
 ----------
 
 vector.\_backends.awkward\_ module
-----------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._backends.awkward_
    :members:
@@ -14,7 +14,7 @@ vector.\_backends.awkward\_ module
    :private-members:
 
 vector.\_backends.numba\_ module
---------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._backends.numba_
    :members:
@@ -23,7 +23,7 @@ vector.\_backends.numba\_ module
    :private-members:
 
 vector.\_backends.numba\_numpy module
--------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._backends.numba_numpy
    :members:
@@ -32,7 +32,7 @@ vector.\_backends.numba\_numpy module
    :private-members:
 
 vector.\_backends.numba\_object module
---------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._backends.numba_object
    :members:
@@ -41,7 +41,7 @@ vector.\_backends.numba\_object module
    :private-members:
 
 vector.\_backends.numpy\_ module
---------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._backends.numpy_
    :members:
@@ -50,7 +50,7 @@ vector.\_backends.numpy\_ module
    :private-members:
 
 vector.\_backends.object\_ module
----------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._backends.object_
    :members:

--- a/docs/api/vector._compute.lorentz.rst
+++ b/docs/api/vector._compute.lorentz.rst
@@ -5,7 +5,7 @@ Submodules
 ----------
 
 vector.\_compute.lorentz.Et module
-----------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.lorentz.Et
    :members:
@@ -14,7 +14,7 @@ vector.\_compute.lorentz.Et module
    :private-members:
 
 vector.\_compute.lorentz.Et2 module
------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.lorentz.Et2
    :members:
@@ -23,7 +23,7 @@ vector.\_compute.lorentz.Et2 module
    :private-members:
 
 vector.\_compute.lorentz.Mt module
-----------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.lorentz.Mt
    :members:
@@ -32,7 +32,7 @@ vector.\_compute.lorentz.Mt module
    :private-members:
 
 vector.\_compute.lorentz.Mt2 module
------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.lorentz.Mt2
    :members:
@@ -41,7 +41,7 @@ vector.\_compute.lorentz.Mt2 module
    :private-members:
 
 vector.\_compute.lorentz.add module
------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.lorentz.add
    :members:
@@ -50,7 +50,7 @@ vector.\_compute.lorentz.add module
    :private-members:
 
 vector.\_compute.lorentz.beta module
-------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.lorentz.beta
    :members:
@@ -59,7 +59,7 @@ vector.\_compute.lorentz.beta module
    :private-members:
 
 vector.\_compute.lorentz.boostX\_beta module
---------------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.lorentz.boostX_beta
    :members:
@@ -68,7 +68,7 @@ vector.\_compute.lorentz.boostX\_beta module
    :private-members:
 
 vector.\_compute.lorentz.boostX\_gamma module
----------------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.lorentz.boostX_gamma
    :members:
@@ -77,7 +77,7 @@ vector.\_compute.lorentz.boostX\_gamma module
    :private-members:
 
 vector.\_compute.lorentz.boostY\_beta module
---------------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.lorentz.boostY_beta
    :members:
@@ -86,7 +86,7 @@ vector.\_compute.lorentz.boostY\_beta module
    :private-members:
 
 vector.\_compute.lorentz.boostY\_gamma module
----------------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.lorentz.boostY_gamma
    :members:
@@ -95,7 +95,7 @@ vector.\_compute.lorentz.boostY\_gamma module
    :private-members:
 
 vector.\_compute.lorentz.boostZ\_beta module
---------------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.lorentz.boostZ_beta
    :members:
@@ -104,7 +104,7 @@ vector.\_compute.lorentz.boostZ\_beta module
    :private-members:
 
 vector.\_compute.lorentz.boostZ\_gamma module
----------------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.lorentz.boostZ_gamma
    :members:
@@ -113,7 +113,7 @@ vector.\_compute.lorentz.boostZ\_gamma module
    :private-members:
 
 vector.\_compute.lorentz.boost\_beta3 module
---------------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.lorentz.boost_beta3
    :members:
@@ -122,7 +122,7 @@ vector.\_compute.lorentz.boost\_beta3 module
    :private-members:
 
 vector.\_compute.lorentz.boost\_p4 module
------------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.lorentz.boost_p4
    :members:
@@ -131,7 +131,7 @@ vector.\_compute.lorentz.boost\_p4 module
    :private-members:
 
 vector.\_compute.lorentz.deltaRapidityPhi module
---------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.lorentz.deltaRapidityPhi
    :members:
@@ -140,7 +140,7 @@ vector.\_compute.lorentz.deltaRapidityPhi module
    :private-members:
 
 vector.\_compute.lorentz.deltaRapidityPhi2 module
----------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.lorentz.deltaRapidityPhi2
    :members:
@@ -149,7 +149,7 @@ vector.\_compute.lorentz.deltaRapidityPhi2 module
    :private-members:
 
 vector.\_compute.lorentz.dot module
------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.lorentz.dot
    :members:
@@ -158,7 +158,7 @@ vector.\_compute.lorentz.dot module
    :private-members:
 
 vector.\_compute.lorentz.equal module
--------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.lorentz.equal
    :members:
@@ -167,7 +167,7 @@ vector.\_compute.lorentz.equal module
    :private-members:
 
 vector.\_compute.lorentz.gamma module
--------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.lorentz.gamma
    :members:
@@ -176,7 +176,7 @@ vector.\_compute.lorentz.gamma module
    :private-members:
 
 vector.\_compute.lorentz.is\_lightlike module
----------------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.lorentz.is_lightlike
    :members:
@@ -185,7 +185,7 @@ vector.\_compute.lorentz.is\_lightlike module
    :private-members:
 
 vector.\_compute.lorentz.is\_spacelike module
----------------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.lorentz.is_spacelike
    :members:
@@ -194,7 +194,7 @@ vector.\_compute.lorentz.is\_spacelike module
    :private-members:
 
 vector.\_compute.lorentz.is\_timelike module
---------------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.lorentz.is_timelike
    :members:
@@ -203,7 +203,7 @@ vector.\_compute.lorentz.is\_timelike module
    :private-members:
 
 vector.\_compute.lorentz.isclose module
----------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.lorentz.isclose
    :members:
@@ -212,7 +212,7 @@ vector.\_compute.lorentz.isclose module
    :private-members:
 
 vector.\_compute.lorentz.not\_equal module
-------------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.lorentz.not_equal
    :members:
@@ -221,7 +221,7 @@ vector.\_compute.lorentz.not\_equal module
    :private-members:
 
 vector.\_compute.lorentz.rapidity module
-----------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.lorentz.rapidity
    :members:
@@ -230,7 +230,7 @@ vector.\_compute.lorentz.rapidity module
    :private-members:
 
 vector.\_compute.lorentz.scale module
--------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.lorentz.scale
    :members:
@@ -239,7 +239,7 @@ vector.\_compute.lorentz.scale module
    :private-members:
 
 vector.\_compute.lorentz.subtract module
-----------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.lorentz.subtract
    :members:
@@ -248,7 +248,7 @@ vector.\_compute.lorentz.subtract module
    :private-members:
 
 vector.\_compute.lorentz.t module
----------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.lorentz.t
    :members:
@@ -257,7 +257,7 @@ vector.\_compute.lorentz.t module
    :private-members:
 
 vector.\_compute.lorentz.t2 module
-----------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.lorentz.t2
    :members:
@@ -266,7 +266,7 @@ vector.\_compute.lorentz.t2 module
    :private-members:
 
 vector.\_compute.lorentz.tau module
------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.lorentz.tau
    :members:
@@ -275,7 +275,7 @@ vector.\_compute.lorentz.tau module
    :private-members:
 
 vector.\_compute.lorentz.tau2 module
-------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.lorentz.tau2
    :members:
@@ -284,7 +284,7 @@ vector.\_compute.lorentz.tau2 module
    :private-members:
 
 vector.\_compute.lorentz.to\_beta3 module
------------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.lorentz.to_beta3
    :members:
@@ -293,7 +293,7 @@ vector.\_compute.lorentz.to\_beta3 module
    :private-members:
 
 vector.\_compute.lorentz.transform4D module
--------------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.lorentz.transform4D
    :members:
@@ -302,7 +302,7 @@ vector.\_compute.lorentz.transform4D module
    :private-members:
 
 vector.\_compute.lorentz.unit module
-------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.lorentz.unit
    :members:

--- a/docs/api/vector._compute.planar.rst
+++ b/docs/api/vector._compute.planar.rst
@@ -5,7 +5,7 @@ Submodules
 ----------
 
 vector.\_compute.planar.add module
-----------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.planar.add
    :members:
@@ -14,7 +14,7 @@ vector.\_compute.planar.add module
    :private-members:
 
 vector.\_compute.planar.deltaphi module
----------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.planar.deltaphi
    :members:
@@ -23,7 +23,7 @@ vector.\_compute.planar.deltaphi module
    :private-members:
 
 vector.\_compute.planar.dot module
-----------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.planar.dot
    :members:
@@ -32,7 +32,7 @@ vector.\_compute.planar.dot module
    :private-members:
 
 vector.\_compute.planar.equal module
-------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.planar.equal
    :members:
@@ -41,7 +41,7 @@ vector.\_compute.planar.equal module
    :private-members:
 
 vector.\_compute.planar.is\_antiparallel module
------------------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.planar.is_antiparallel
    :members:
@@ -50,7 +50,7 @@ vector.\_compute.planar.is\_antiparallel module
    :private-members:
 
 vector.\_compute.planar.is\_parallel module
--------------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.planar.is_parallel
    :members:
@@ -59,7 +59,7 @@ vector.\_compute.planar.is\_parallel module
    :private-members:
 
 vector.\_compute.planar.is\_perpendicular module
-------------------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.planar.is_perpendicular
    :members:
@@ -68,7 +68,7 @@ vector.\_compute.planar.is\_perpendicular module
    :private-members:
 
 vector.\_compute.planar.isclose module
---------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.planar.isclose
    :members:
@@ -77,7 +77,7 @@ vector.\_compute.planar.isclose module
    :private-members:
 
 vector.\_compute.planar.not\_equal module
------------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.planar.not_equal
    :members:
@@ -86,7 +86,7 @@ vector.\_compute.planar.not\_equal module
    :private-members:
 
 vector.\_compute.planar.phi module
-----------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.planar.phi
    :members:
@@ -95,7 +95,7 @@ vector.\_compute.planar.phi module
    :private-members:
 
 vector.\_compute.planar.rho module
-----------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.planar.rho
    :members:
@@ -104,7 +104,7 @@ vector.\_compute.planar.rho module
    :private-members:
 
 vector.\_compute.planar.rho2 module
------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.planar.rho2
    :members:
@@ -113,7 +113,7 @@ vector.\_compute.planar.rho2 module
    :private-members:
 
 vector.\_compute.planar.rotateZ module
---------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.planar.rotateZ
    :members:
@@ -122,7 +122,7 @@ vector.\_compute.planar.rotateZ module
    :private-members:
 
 vector.\_compute.planar.scale module
-------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.planar.scale
    :members:
@@ -131,7 +131,7 @@ vector.\_compute.planar.scale module
    :private-members:
 
 vector.\_compute.planar.subtract module
----------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.planar.subtract
    :members:
@@ -140,7 +140,7 @@ vector.\_compute.planar.subtract module
    :private-members:
 
 vector.\_compute.planar.transform2D module
-------------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.planar.transform2D
    :members:
@@ -149,7 +149,7 @@ vector.\_compute.planar.transform2D module
    :private-members:
 
 vector.\_compute.planar.unit module
------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.planar.unit
    :members:
@@ -158,7 +158,7 @@ vector.\_compute.planar.unit module
    :private-members:
 
 vector.\_compute.planar.x module
---------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.planar.x
    :members:
@@ -167,7 +167,7 @@ vector.\_compute.planar.x module
    :private-members:
 
 vector.\_compute.planar.y module
---------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.planar.y
    :members:

--- a/docs/api/vector._compute.spatial.rst
+++ b/docs/api/vector._compute.spatial.rst
@@ -5,7 +5,7 @@ Submodules
 ----------
 
 vector.\_compute.spatial.add module
------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.spatial.add
    :members:
@@ -14,7 +14,7 @@ vector.\_compute.spatial.add module
    :private-members:
 
 vector.\_compute.spatial.costheta module
-----------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.spatial.costheta
    :members:
@@ -23,7 +23,7 @@ vector.\_compute.spatial.costheta module
    :private-members:
 
 vector.\_compute.spatial.cottheta module
-----------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.spatial.cottheta
    :members:
@@ -32,7 +32,7 @@ vector.\_compute.spatial.cottheta module
    :private-members:
 
 vector.\_compute.spatial.cross module
--------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.spatial.cross
    :members:
@@ -41,7 +41,7 @@ vector.\_compute.spatial.cross module
    :private-members:
 
 vector.\_compute.spatial.deltaR module
---------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.spatial.deltaR
    :members:
@@ -50,7 +50,7 @@ vector.\_compute.spatial.deltaR module
    :private-members:
 
 vector.\_compute.spatial.deltaR2 module
----------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.spatial.deltaR2
    :members:
@@ -59,7 +59,7 @@ vector.\_compute.spatial.deltaR2 module
    :private-members:
 
 vector.\_compute.spatial.deltaangle module
-------------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.spatial.deltaangle
    :members:
@@ -68,7 +68,7 @@ vector.\_compute.spatial.deltaangle module
    :private-members:
 
 vector.\_compute.spatial.deltaeta module
-----------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.spatial.deltaeta
    :members:
@@ -77,7 +77,7 @@ vector.\_compute.spatial.deltaeta module
    :private-members:
 
 vector.\_compute.spatial.dot module
------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.spatial.dot
    :members:
@@ -86,7 +86,7 @@ vector.\_compute.spatial.dot module
    :private-members:
 
 vector.\_compute.spatial.equal module
--------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.spatial.equal
    :members:
@@ -95,7 +95,7 @@ vector.\_compute.spatial.equal module
    :private-members:
 
 vector.\_compute.spatial.eta module
------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.spatial.eta
    :members:
@@ -104,7 +104,7 @@ vector.\_compute.spatial.eta module
    :private-members:
 
 vector.\_compute.spatial.is\_antiparallel module
-------------------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.spatial.is_antiparallel
    :members:
@@ -113,7 +113,7 @@ vector.\_compute.spatial.is\_antiparallel module
    :private-members:
 
 vector.\_compute.spatial.is\_parallel module
---------------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.spatial.is_parallel
    :members:
@@ -122,7 +122,7 @@ vector.\_compute.spatial.is\_parallel module
    :private-members:
 
 vector.\_compute.spatial.is\_perpendicular module
--------------------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.spatial.is_perpendicular
    :members:
@@ -131,7 +131,7 @@ vector.\_compute.spatial.is\_perpendicular module
    :private-members:
 
 vector.\_compute.spatial.isclose module
----------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.spatial.isclose
    :members:
@@ -140,7 +140,7 @@ vector.\_compute.spatial.isclose module
    :private-members:
 
 vector.\_compute.spatial.mag module
------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.spatial.mag
    :members:
@@ -149,7 +149,7 @@ vector.\_compute.spatial.mag module
    :private-members:
 
 vector.\_compute.spatial.mag2 module
-------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.spatial.mag2
    :members:
@@ -158,7 +158,7 @@ vector.\_compute.spatial.mag2 module
    :private-members:
 
 vector.\_compute.spatial.not\_equal module
-------------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.spatial.not_equal
    :members:
@@ -167,7 +167,7 @@ vector.\_compute.spatial.not\_equal module
    :private-members:
 
 vector.\_compute.spatial.rotateX module
----------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.spatial.rotateX
    :members:
@@ -176,7 +176,7 @@ vector.\_compute.spatial.rotateX module
    :private-members:
 
 vector.\_compute.spatial.rotateY module
----------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.spatial.rotateY
    :members:
@@ -185,7 +185,7 @@ vector.\_compute.spatial.rotateY module
    :private-members:
 
 vector.\_compute.spatial.rotate\_axis module
---------------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.spatial.rotate_axis
    :members:
@@ -194,7 +194,7 @@ vector.\_compute.spatial.rotate\_axis module
    :private-members:
 
 vector.\_compute.spatial.rotate\_euler module
----------------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.spatial.rotate_euler
    :members:
@@ -203,7 +203,7 @@ vector.\_compute.spatial.rotate\_euler module
    :private-members:
 
 vector.\_compute.spatial.rotate\_quaternion module
---------------------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.spatial.rotate_quaternion
    :members:
@@ -212,7 +212,7 @@ vector.\_compute.spatial.rotate\_quaternion module
    :private-members:
 
 vector.\_compute.spatial.scale module
--------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.spatial.scale
    :members:
@@ -221,7 +221,7 @@ vector.\_compute.spatial.scale module
    :private-members:
 
 vector.\_compute.spatial.subtract module
-----------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.spatial.subtract
    :members:
@@ -230,7 +230,7 @@ vector.\_compute.spatial.subtract module
    :private-members:
 
 vector.\_compute.spatial.theta module
--------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.spatial.theta
    :members:
@@ -239,7 +239,7 @@ vector.\_compute.spatial.theta module
    :private-members:
 
 vector.\_compute.spatial.transform3D module
--------------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.spatial.transform3D
    :members:
@@ -248,7 +248,7 @@ vector.\_compute.spatial.transform3D module
    :private-members:
 
 vector.\_compute.spatial.unit module
-------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.spatial.unit
    :members:
@@ -257,7 +257,7 @@ vector.\_compute.spatial.unit module
    :private-members:
 
 vector.\_compute.spatial.z module
----------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: vector._compute.spatial.z
    :members:

--- a/docs/api/vector._methods.rst
+++ b/docs/api/vector._methods.rst
@@ -1,0 +1,8 @@
+vector.\_methods module
+=======================
+
+.. automodule:: vector._methods
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :private-members:

--- a/docs/api/vector._typeutils.rst
+++ b/docs/api/vector._typeutils.rst
@@ -1,0 +1,8 @@
+vector.\_typeutils module
+=========================
+
+.. automodule:: vector._typeutils
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :private-members:

--- a/docs/api/vector.rst
+++ b/docs/api/vector.rst
@@ -5,7 +5,7 @@ Subpackages
 -----------
 
 .. toctree::
-   :maxdepth: 4
+   :maxdepth: 5
 
    vector._backends
    vector._compute
@@ -13,38 +13,10 @@ Subpackages
 Submodules
 ----------
 
-vector.\_methods module
------------------------
+.. toctree::
+   :maxdepth: 1
 
-.. automodule:: vector._methods
-   :members:
-   :undoc-members:
-   :show-inheritance:
-   :private-members:
+   vector._methods
+   vector._typeutils
+   vector.version
 
-vector.\_typeutils module
--------------------------
-
-.. automodule:: vector._typeutils
-   :members:
-   :undoc-members:
-   :show-inheritance:
-   :private-members:
-
-vector.version module
----------------------
-
-.. automodule:: vector.version
-   :members:
-   :undoc-members:
-   :show-inheritance:
-   :private-members:
-
-Module contents
----------------
-
-.. automodule:: vector
-   :members:
-   :undoc-members:
-   :show-inheritance:
-   :private-members:

--- a/docs/api/vector.version.rst
+++ b/docs/api/vector.version.rst
@@ -1,0 +1,8 @@
+vector.version module
+=====================
+
+.. automodule:: vector.version
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :private-members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,7 +19,7 @@ Main features of Vector:
    * `Awkward Arrays <https://awkward-array.org/>`_ of vectors
    * potential for more: CuPy, TensorFlow, Torch, JAX...
 * NumPy/Awkward backends also implemented in `Numba <https://numba.pydata.org/>`_ for JIT-compiled calculations on vectors.
-* Distinction between geometrical vectors, which have a minimum of attribute and method names, and vectors representing momentum, which have synonyms like `pt` = `rho`, `energy` = `t`, `mass` = `tau`.
+* Distinction between geometrical vectors, which have a minimum of attribute and method names, and vectors representing momentum, which have synonyms like ``pt`` = ``rho``, ``energy`` = ``t``, ``mass`` = ``tau``.
 
 
 .. toctree::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,9 +6,25 @@
 Vector: vectorized 2D, 3D, and Lorentz vectors
 ==============================================
 
+Vector is a Python 3.6+ library for 2D, 3D, and `Lorentz vectors <https://en.wikipedia.org/wiki/Special_relativity#Physics_in_spacetime>`_, especially _arrays of vectors\_, to solve common physics problems in a NumPy-like way.
+
+Main features of Vector:
+
+* Pure Python with NumPy as its only dependency. This makes it easier to install.
+* Vectors may be represented in a variety of coordinate systems: Cartesian, cylindrical, pseudorapidity, and any combination of these with time or proper time for Lorentz vectors. In all, there are 12 coordinate systems: {*x* - *y* vs *ρ* - *φ* in the azimuthal plane} × {*z* vs *θ* vs *η* longitudinally} × {*t* vs *τ* temporally}.
+* Uses names and conventions set by `ROOT <https://root.cern/>`_'s `TLorentzVector <https://root.cern.ch/doc/master/classTLorentzVector.html>`_ and `Math::LorentzVector <https://root.cern.ch/doc/master/classROOT_1_1Math_1_1LorentzVector.html>`_, as well as `scikit-hep/math <https://github.com/scikit-hep/scikit-hep/tree/master/skhep/math>`_, `uproot-methods TLorentzVector <https://github.com/scikit-hep/uproot3-methods/blob/master/uproot3_methods/classes/TLorentzVector.py>`_, `henryiii/hepvector <https://github.com/henryiii/hepvector>`_, and `coffea.nanoevents.methods.vector <https://coffeateam.github.io/coffea/modules/coffea.nanoevents.methods.vector.html>`_.
+* Implemented on a variety of backends:
+   * pure Python objects
+   * NumPy arrays of vectors (as a `structured array <https://numpy.org/doc/stable/user/basics.rec.html>`_ subclass)
+   * `Awkward Arrays <https://awkward-array.org/>`_ of vectors
+   * potential for more: CuPy, TensorFlow, Torch, JAX...
+* NumPy/Awkward backends also implemented in `Numba <https://numba.pydata.org/>`_ for JIT-compiled calculations on vectors.
+* Distinction between geometrical vectors, which have a minimum of attribute and method names, and vectors representing momentum, which have synonyms like `pt` = `rho`, `energy` = `t`, `mass` = `tau`.
+
+
 .. toctree::
-   :maxdepth: 2
-   :caption: Contents:
+   :maxdepth: 1
+   :caption: Using vector
 
    usage/intro
    usage/structure
@@ -17,7 +33,7 @@ Vector: vectorized 2D, 3D, and Lorentz vectors
 
 .. toctree::
    :maxdepth: 3
-   :caption: API Reference:
+   :caption: API Reference
 
    api/modules.rst
 

--- a/docs/usage/intro.ipynb
+++ b/docs/usage/intro.ipynb
@@ -2310,7 +2310,7 @@
     "   * `tau` (`M`, `mass`): see note above\n",
     "   * `tau2` (`M2`, `mass2`)\n",
     "   * `beta`: scalar(s) between $0$ (inclusive) and $1$ (exclusive, unless the vector components are infinite)\n",
-    "   * `deltaRapidityPhi`: $Delta R_{\mbox{rapidity}} = \Delta\phi^2 + \Delta \mbox{rapidity}^2$\n",
+    "   * `deltaRapidityPhi`: $\\Delta R_{\\mbox{rapidity}} = \\Delta\\phi^2 + \\Delta \\mbox{rapidity}^2$\n",
     "   * `deltaRapidityPhi2`: the above, squared\n",
     "   * `gamma`: scalar(s) between $1$ (inclusive) and $\\infty$\n",
     "   * `rapidity`: scalar(s) between $0$ (inclusive) and $\\infty$\n",
@@ -2479,7 +2479,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -2493,7 +2493,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.2"
+   "version": "3.9.0"
   }
  },
  "nbformat": 4,

--- a/src/vector/_backends/__init__.py
+++ b/src/vector/_backends/__init__.py
@@ -2,3 +2,9 @@
 #
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
+"""
+Vector comes loaded with 3 + 2 backends; a pure Python object backend, a NumPy backend, an Awkward
+Array backend, an Object-Numba, and an Awkward-Numba backend to leverage JIT (Just In Time) compiled
+calculations on vectors. Other potential future vanilla backends include Tensorflow and JAX, and
+other possible future Numba-backends include Numba-NumPy.
+"""


### PR DESCRIPTION
## Issues
- The intro notebook is currently broken because of missing extra `\`s when writing latex.
- There are no differences between `H2` and `H3` headings which makes the index in the documentation behave weirdly.

## Changes done
1. All the submodule headings are now `H3` and the headings saying "Submodule" are `H2`.
2. Vector's direct submodules have their independent `rst` files and pages now (The documentation for the submodules currently renders directly in the index page).
3. Added information about vector on the landing page.
4. Fixed the intro notebook.

## Screenshots
### Sidebar index
**Current**

![image](https://user-images.githubusercontent.com/74055102/169544725-8c77e799-0d22-4ed3-8afc-40ec6d9bf0b2.png)

**New**

![image](https://user-images.githubusercontent.com/74055102/169544805-8af67566-e3bb-450a-9f2f-c76471cd087b.png)

### vector index

**Current**

![image](https://user-images.githubusercontent.com/74055102/169545025-33c73030-bfec-4c2b-aaf7-9317465cb099.png)

**New**

![image](https://user-images.githubusercontent.com/74055102/169545113-dd1365ee-d605-4a38-9351-8e247547f68d.png)

### vector package index

**Current**

![image](https://user-images.githubusercontent.com/74055102/169545258-ef1f5e33-b105-42cf-b3b8-0bfba865a35a.png)

**New**

![image](https://user-images.githubusercontent.com/74055102/169545421-6578c32a-412b-48a1-9e1a-ec71592aa3bc.png)

### Direct submodule documentation

**Current**

![image](https://user-images.githubusercontent.com/74055102/169545582-cbb718f5-d826-499c-b526-2ba3d73eb3d9.png)

**New**

![image](https://user-images.githubusercontent.com/74055102/169545722-fa20ae9e-0e75-440d-89b5-055b3b1cd742.png)

### Contents bar

**Current**

![image](https://user-images.githubusercontent.com/74055102/169547960-eae299f0-4e1b-41b9-9bc5-502b70ddd68e.png)

**New**

![image](https://user-images.githubusercontent.com/74055102/169547861-1fc60aef-aff2-40a6-8f65-9b88b89f1d90.png)

