### PR TITLE
docs: fix warnings

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,7 +41,7 @@ extensions = [
     "sphinx_math_dollar",
 ]
 
-mathjax_config = {
+mathjax3_config = {
     "tex2jax": {
         "inlineMath": [["\\(", "\\)"]],
         "displayMath": [["\\[", "\\]"]],

--- a/src/vector/__init__.py
+++ b/src/vector/__init__.py
@@ -163,7 +163,7 @@ def register_awkward() -> None:
     vector properties and methods.
 
     If you do not call this function, only arrays created with
-    :doc:`vector.Array` (or derived from such an array) have vector properties
+    :func:`vector.Array` (or derived from such an array) have vector properties
     and methods.
     """
     import awkward

--- a/src/vector/_backends/awkward_.py
+++ b/src/vector/_backends/awkward_.py
@@ -93,7 +93,7 @@ class AzimuthalAwkward(CoordinatesAwkward, Azimuthal):
     @classmethod
     def from_fields(cls, array: ak.Array) -> "AzimuthalAwkward":
         """
-        Create a :class:`vector.backends.awkward.AzimuthalAwkwardXY` or a
+        Create a :class:`vector._backends.awkward_.AzimuthalAwkwardXY` or a
         :class:`vector._backends.awkward_.AzimuthalAwkwardRhoPhi`, depending on
         the fields in ``array``.
         """
@@ -111,7 +111,7 @@ class AzimuthalAwkward(CoordinatesAwkward, Azimuthal):
     @classmethod
     def from_momentum_fields(cls, array: ak.Array) -> "AzimuthalAwkward":
         """
-        Create a :class:`vector.backends.awkward.AzimuthalAwkwardXY` or a
+        Create a :class:`vector._backends.awkward_.AzimuthalAwkwardXY` or a
         :class:`vector._backends.awkward_.AzimuthalAwkwardRhoPhi`, depending on
         the fields in ``array``, allowing momentum synonyms.
         """

--- a/src/vector/_backends/awkward_.py
+++ b/src/vector/_backends/awkward_.py
@@ -93,8 +93,8 @@ class AzimuthalAwkward(CoordinatesAwkward, Azimuthal):
     @classmethod
     def from_fields(cls, array: ak.Array) -> "AzimuthalAwkward":
         """
-        Create a :doc:`vector._backends.awkward_.AzimuthalAwkwardXY` or a
-        :doc:`vector._backends.awkward_.AzimuthalAwkwardRhoPhi`, depending on
+        Create a :class:`vector.backends.awkward.AzimuthalAwkwardXY` or a
+        :class:`vector._backends.awkward_.AzimuthalAwkwardRhoPhi`, depending on
         the fields in ``array``.
         """
         fields = ak.fields(array)
@@ -111,8 +111,8 @@ class AzimuthalAwkward(CoordinatesAwkward, Azimuthal):
     @classmethod
     def from_momentum_fields(cls, array: ak.Array) -> "AzimuthalAwkward":
         """
-        Create a :doc:`vector._backends.awkward_.AzimuthalAwkwardXY` or a
-        :doc:`vector._backends.awkward_.AzimuthalAwkwardRhoPhi`, depending on
+        Create a :class:`vector.backends.awkward.AzimuthalAwkwardXY` or a
+        :class:`vector._backends.awkward_.AzimuthalAwkwardRhoPhi`, depending on
         the fields in ``array``, allowing momentum synonyms.
         """
         fields = ak.fields(array)
@@ -139,9 +139,9 @@ class LongitudinalAwkward(CoordinatesAwkward, Longitudinal):
     @classmethod
     def from_fields(cls, array: ak.Array) -> "LongitudinalAwkward":
         """
-        Create a :doc:`vector._backends.awkward_.LongitudinalAwkwardZ`, a
-        :doc:`vector._backends.awkward_.LongitudinalAwkwardTheta`, or a
-        :doc:`vector._backends.awkward_.LongitudinalAwkwardEta`, depending on
+        Create a :class:`vector._backends.awkward_.LongitudinalAwkwardZ`, a
+        :class:`vector._backends.awkward_.LongitudinalAwkwardTheta`, or a
+        :class:`vector._backends.awkward_.LongitudinalAwkwardEta`, depending on
         the fields in ``array``.
         """
         fields = ak.fields(array)
@@ -160,9 +160,9 @@ class LongitudinalAwkward(CoordinatesAwkward, Longitudinal):
     @classmethod
     def from_momentum_fields(cls, array: ak.Array) -> "LongitudinalAwkward":
         """
-        Create a :doc:`vector._backends.awkward_.LongitudinalAwkwardZ`, a
-        :doc:`vector._backends.awkward_.LongitudinalAwkwardTheta`, or a
-        :doc:`vector._backends.awkward_.LongitudinalAwkwardEta`, depending on
+        Create a :class:`vector._backends.awkward_.LongitudinalAwkwardZ`, a
+        :class:`vector._backends.awkward_.LongitudinalAwkwardTheta`, or a
+        :class:`vector._backends.awkward_.LongitudinalAwkwardEta`, depending on
         the fields in ``array``, allowing momentum synonyms.
         """
         fields = ak.fields(array)
@@ -185,8 +185,8 @@ class TemporalAwkward(CoordinatesAwkward, Temporal):
     @classmethod
     def from_fields(cls, array: ak.Array) -> "TemporalAwkward":
         """
-        Create a :doc:`vector._backends.awkward_.TemporalT` or a
-        :doc:`vector._backends.awkward_.TemporalTau`, depending on
+        Create a :class:`vector._backends.awkward_.TemporalT` or a
+        :class:`vector._backends.awkward_.TemporalTau`, depending on
         the fields in ``array``.
         """
         fields = ak.fields(array)
@@ -203,8 +203,8 @@ class TemporalAwkward(CoordinatesAwkward, Temporal):
     @classmethod
     def from_momentum_fields(cls, array: ak.Array) -> "TemporalAwkward":
         """
-        Create a :doc:`vector._backends.awkward_.TemporalT` or a
-        :doc:`vector._backends.awkward_.TemporalTau`, depending on
+        Create a :class:`vector._backends.awkward_.TemporalT` or a
+        :class:`vector._backends.awkward_.TemporalTau`, depending on
         the fields in ``array``, allowing momentum synonyms.
         """
         fields = ak.fields(array)

--- a/src/vector/_backends/object_.py
+++ b/src/vector/_backends/object_.py
@@ -1471,7 +1471,7 @@ def _gather_coordinates(
     coordinates: typing.Dict[str, typing.Any],
 ) -> typing.Any:
     """
-    Helper function for :func:`vector._backends._.obj`.
+    Helper function for :func:`vector._backends.object_.obj`.
     """
     azimuthal: typing.Optional[
         typing.Union[AzimuthalObjectXY, AzimuthalObjectRhoPhi]

--- a/src/vector/_backends/object_.py
+++ b/src/vector/_backends/object_.py
@@ -441,7 +441,7 @@ class VectorObject2D(VectorObject, Planar, Vector2D):
         """
         Constructs a ``VectorObject2D`` from Cartesian coordinates.
 
-        Use :doc:`vector._backends.object_.MomentumObject2D` to construct a vector
+        Use :class:`vector._backends.object_.MomentumObject2D` to construct a vector
         with momentum properties and methods.
         """
         return cls(AzimuthalObjectXY(x, y))
@@ -451,7 +451,7 @@ class VectorObject2D(VectorObject, Planar, Vector2D):
         """
         Constructs a ``VectorObject2D`` from polar coordinates.
 
-        Use :doc:`vector._backends.object_.MomentumObject2D` to construct a vector
+        Use :class:`vector._backends.object_.MomentumObject2D` to construct a vector
         with momentum properties and methods.
         """
         return cls(AzimuthalObjectRhoPhi(rho, phi))
@@ -640,7 +640,7 @@ class VectorObject3D(VectorObject, Spatial, Vector3D):
         """
         Constructs a ``VectorObject3D`` from Cartesian coordinates.
 
-        Use :doc:`vector._backends.object_.MomentumObject3D` to construct a vector
+        Use :class:`vector._backends.object_.MomentumObject3D` to construct a vector
         with momentum properties and methods.
         """
         return cls(AzimuthalObjectXY(x, y), LongitudinalObjectZ(z))
@@ -651,7 +651,7 @@ class VectorObject3D(VectorObject, Spatial, Vector3D):
         Constructs a ``VectorObject3D`` from Cartesian azimuthal coordinates and
         a polar angle $\theta$.
 
-        Use :doc:`vector._backends.object_.MomentumObject3D` to construct a vector
+        Use :class:`vector._backends.object_.MomentumObject3D` to construct a vector
         with momentum properties and methods.
         """
         return cls(AzimuthalObjectXY(x, y), LongitudinalObjectTheta(theta))
@@ -662,7 +662,7 @@ class VectorObject3D(VectorObject, Spatial, Vector3D):
         Constructs a ``VectorObject3D`` from Cartesian coordinates and a
         pseudorapidity $\eta$.
 
-        Use :doc:`vector._backends.object_.MomentumObject3D` to construct a vector
+        Use :class:`vector._backends.object_.MomentumObject3D` to construct a vector
         with momentum properties and methods.
         """
         return cls(AzimuthalObjectXY(x, y), LongitudinalObjectEta(eta))
@@ -673,7 +673,7 @@ class VectorObject3D(VectorObject, Spatial, Vector3D):
         Constructs a ``VectorObject3D`` from polar azimuthal coordinates and a
         Cartesian longitudinal coordinate $z$.
 
-        Use :doc:`vector._backends.object_.MomentumObject3D` to construct a vector
+        Use :class:`vector._backends.object_.MomentumObject3D` to construct a vector
         with momentum properties and methods.
         """
         return cls(AzimuthalObjectRhoPhi(rho, phi), LongitudinalObjectZ(z))
@@ -684,7 +684,7 @@ class VectorObject3D(VectorObject, Spatial, Vector3D):
         Constructs a ``VectorObject3D`` from polar azimuthal coordinates and a
         polar angle $\theta$.
 
-        Use :doc:`vector._backends.object_.MomentumObject3D` to construct a vector
+        Use :class:`vector._backends.object_.MomentumObject3D` to construct a vector
         with momentum properties and methods.
         """
         return cls(AzimuthalObjectRhoPhi(rho, phi), LongitudinalObjectTheta(theta))
@@ -695,7 +695,7 @@ class VectorObject3D(VectorObject, Spatial, Vector3D):
         Constructs a ``VectorObject3D`` from polar azimuthal coordinates and a
         pseudorapidity $\eta$.
 
-        Use :doc:`vector._backends.object_.MomentumObject3D` to construct a vector
+        Use :class:`vector._backends.object_.MomentumObject3D` to construct a vector
         with momentum properties and methods.
         """
         return cls(AzimuthalObjectRhoPhi(rho, phi), LongitudinalObjectEta(eta))
@@ -938,7 +938,7 @@ class VectorObject4D(VectorObject, Lorentz, Vector4D):
         Constructs a ``VectorObject3D`` from Cartesian coordinates and a time
         coordinate $t$.
 
-        Use :doc:`vector._backends.object_.MomentumObject3D` to construct a vector
+        Use :class:`vector._backends.object_.MomentumObject3D` to construct a vector
         with momentum properties and methods.
         """
         return cls(AzimuthalObjectXY(x, y), LongitudinalObjectZ(z), TemporalObjectT(t))
@@ -955,7 +955,7 @@ class VectorObject4D(VectorObject, Lorentz, Vector4D):
         Constructs a ``VectorObject3D`` from Cartesian coordinates and a proper time
         coordinate $\tau$.
 
-        Use :doc:`vector._backends.object_.MomentumObject3D` to construct a vector
+        Use :class:`vector._backends.object_.MomentumObject3D` to construct a vector
         with momentum properties and methods.
         """
         return cls(
@@ -974,7 +974,7 @@ class VectorObject4D(VectorObject, Lorentz, Vector4D):
         Constructs a ``VectorObject3D`` from Cartesian azimuthal coordinates, a
         polar angle $\theta$, and a time coordinate $t$.
 
-        Use :doc:`vector._backends.object_.MomentumObject3D` to construct a vector
+        Use :class:`vector._backends.object_.MomentumObject3D` to construct a vector
         with momentum properties and methods.
         """
         return cls(
@@ -993,7 +993,7 @@ class VectorObject4D(VectorObject, Lorentz, Vector4D):
         Constructs a ``VectorObject3D`` from Cartesian azimuthal coordinates, a
         polar angle $\theta$, and a proper time coordinate $\tau$.
 
-        Use :doc:`vector._backends.object_.MomentumObject3D` to construct a vector
+        Use :class:`vector._backends.object_.MomentumObject3D` to construct a vector
         with momentum properties and methods.
         """
         return cls(
@@ -1014,7 +1014,7 @@ class VectorObject4D(VectorObject, Lorentz, Vector4D):
         Constructs a ``VectorObject3D`` from Cartesian coordinates, a pseudorapidity
         $\eta$, and a time coordinate $t$.
 
-        Use :doc:`vector._backends.object_.MomentumObject3D` to construct a vector
+        Use :class:`vector._backends.object_.MomentumObject3D` to construct a vector
         with momentum properties and methods.
         """
         return cls(
@@ -1033,7 +1033,7 @@ class VectorObject4D(VectorObject, Lorentz, Vector4D):
         Constructs a ``VectorObject3D`` from Cartesian coordinates, a pseudorapidity
         $\eta$, and a proper time coordinate $\tau$.
 
-        Use :doc:`vector._backends.object_.MomentumObject3D` to construct a vector
+        Use :class:`vector._backends.object_.MomentumObject3D` to construct a vector
         with momentum properties and methods.
         """
         return cls(
@@ -1052,7 +1052,7 @@ class VectorObject4D(VectorObject, Lorentz, Vector4D):
         Constructs a ``VectorObject3D`` from polar azimuthal coordinates, a Cartesian
         longitudinal coordinate $z$, and a time coordinate $t$.
 
-        Use :doc:`vector._backends.object_.MomentumObject3D` to construct a vector
+        Use :class:`vector._backends.object_.MomentumObject3D` to construct a vector
         with momentum properties and methods.
         """
         return cls(
@@ -1071,7 +1071,7 @@ class VectorObject4D(VectorObject, Lorentz, Vector4D):
         Constructs a ``VectorObject3D`` from polar azimuthal coordinates, a Cartesian
         longitudinal coordinate $z$, and a proper time coordinate $\tau$.
 
-        Use :doc:`vector._backends.object_.MomentumObject3D` to construct a vector
+        Use :class:`vector._backends.object_.MomentumObject3D` to construct a vector
         with momentum properties and methods.
         """
         return cls(
@@ -1092,7 +1092,7 @@ class VectorObject4D(VectorObject, Lorentz, Vector4D):
         Constructs a ``VectorObject3D`` from polar azimuthal coordinates, a polar
         angle $\theta$, and a time coordinate $t$.
 
-        Use :doc:`vector._backends.object_.MomentumObject3D` to construct a vector
+        Use :class:`vector._backends.object_.MomentumObject3D` to construct a vector
         with momentum properties and methods.
         """
         return cls(
@@ -1113,7 +1113,7 @@ class VectorObject4D(VectorObject, Lorentz, Vector4D):
         Constructs a ``VectorObject3D`` from polar azimuthal coordinates, a polar
         angle $\theta$, and a proper time coordinate $\tau$.
 
-        Use :doc:`vector._backends.object_.MomentumObject3D` to construct a vector
+        Use :class:`vector._backends.object_.MomentumObject3D` to construct a vector
         with momentum properties and methods.
         """
         return cls(
@@ -1134,7 +1134,7 @@ class VectorObject4D(VectorObject, Lorentz, Vector4D):
         Constructs a ``VectorObject3D`` from polar azimuthal coordinates, a
         pseudorapidity $\eta$, and a time coordinate $t$.
 
-        Use :doc:`vector._backends.object_.MomentumObject3D` to construct a vector
+        Use :class:`vector._backends.object_.MomentumObject3D` to construct a vector
         with momentum properties and methods.
         """
         return cls(
@@ -1155,7 +1155,7 @@ class VectorObject4D(VectorObject, Lorentz, Vector4D):
         Constructs a ``VectorObject3D`` from polar azimuthal coordinates, a
         pseudorapidity $\eta$, and a proper time coordinate $\tau$.
 
-        Use :doc:`vector._backends.object_.MomentumObject3D` to construct a vector
+        Use :class:`vector._backends.object_.MomentumObject3D` to construct a vector
         with momentum properties and methods.
         """
         return cls(
@@ -1471,7 +1471,7 @@ def _gather_coordinates(
     coordinates: typing.Dict[str, typing.Any],
 ) -> typing.Any:
     """
-    Helper function for :doc:`vector._backends.object_.obj`.
+    Helper function for :func:`vector._backends._.obj`.
     """
     azimuthal: typing.Optional[
         typing.Union[AzimuthalObjectXY, AzimuthalObjectRhoPhi]
@@ -2704,33 +2704,33 @@ def obj(**coordinates: float) -> VectorObject:
     if they are not numbers, mathematical operations will fail. Usually, you want
     them to be ``int`` or ``float``.
 
-    Alternatively, the :doc:`vector._backends.object_.VectorObject2D`,
-    :doc:`vector._backends.object_.VectorObject3D`, and
-    :doc:`vector._backends.object_.VectorObject4D` classes (with momentum
+    Alternatively, the :class:`vector._backends.object_.VectorObject2D`,
+    :class:`vector._backends.object_.VectorObject3D`, and
+    :class:`vector._backends.object_.VectorObject4D` classes (with momentum
     subclasses) have explicit constructors:
 
-    - :doc:`vector._backends.object_.VectorObject2D.from_xy`
-    - :doc:`vector._backends.object_.VectorObject2D.from_rhophi`
+    - :meth:`vector._backends.object_.VectorObject2D.from_xy`
+    - :meth:`vector._backends.object_.VectorObject2D.from_rhophi`
 
-    - :doc:`vector._backends.object_.VectorObject3D.from_xyz`
-    - :doc:`vector._backends.object_.VectorObject3D.from_xytheta`
-    - :doc:`vector._backends.object_.VectorObject3D.from_xyeta`
-    - :doc:`vector._backends.object_.VectorObject3D.from_rhophiz`
-    - :doc:`vector._backends.object_.VectorObject3D.from_rhophitheta`
-    - :doc:`vector._backends.object_.VectorObject3D.from_rhophieta`
+    - :meth:`vector._backends.object_.VectorObject3D.from_xyz`
+    - :meth:`vector._backends.object_.VectorObject3D.from_xytheta`
+    - :meth:`vector._backends.object_.VectorObject3D.from_xyeta`
+    - :meth:`vector._backends.object_.VectorObject3D.from_rhophiz`
+    - :meth:`vector._backends.object_.VectorObject3D.from_rhophitheta`
+    - :meth:`vector._backends.object_.VectorObject3D.from_rhophieta`
 
-    - :doc:`vector._backends.object_.VectorObject4D.from_xyzt`
-    - :doc:`vector._backends.object_.VectorObject4D.from_xyztau`
-    - :doc:`vector._backends.object_.VectorObject4D.from_xythetat`
-    - :doc:`vector._backends.object_.VectorObject4D.from_xythetatau`
-    - :doc:`vector._backends.object_.VectorObject4D.from_xyetat`
-    - :doc:`vector._backends.object_.VectorObject4D.from_xyetatau`
-    - :doc:`vector._backends.object_.VectorObject4D.from_rhophizt`
-    - :doc:`vector._backends.object_.VectorObject4D.from_rhophiztau`
-    - :doc:`vector._backends.object_.VectorObject4D.from_rhophithetat`
-    - :doc:`vector._backends.object_.VectorObject4D.from_rhophithetatau`
-    - :doc:`vector._backends.object_.VectorObject4D.from_rhophietat`
-    - :doc:`vector._backends.object_.VectorObject4D.from_rhophietatau`
+    - :meth:`vector._backends.object_.VectorObject4D.from_xyzt`
+    - :meth:`vector._backends.object_.VectorObject4D.from_xyztau`
+    - :meth:`vector._backends.object_.VectorObject4D.from_xythetat`
+    - :meth:`vector._backends.object_.VectorObject4D.from_xythetatau`
+    - :meth:`vector._backends.object_.VectorObject4D.from_xyetat`
+    - :meth:`vector._backends.object_.VectorObject4D.from_xyetatau`
+    - :meth:`vector._backends.object_.VectorObject4D.from_rhophizt`
+    - :meth:`vector._backends.object_.VectorObject4D.from_rhophiztau`
+    - :meth:`vector._backends.object_.VectorObject4D.from_rhophithetat`
+    - :meth:`vector._backends.object_.VectorObject4D.from_rhophithetatau`
+    - :meth:`vector._backends.object_.VectorObject4D.from_rhophietat`
+    - :meth:`vector._backends.object_.VectorObject4D.from_rhophietatau`
     """
     is_momentum = False
     generic_coordinates = {}

--- a/src/vector/_methods.py
+++ b/src/vector/_methods.py
@@ -142,6 +142,8 @@ class VectorProtocol:
             vectors without momentum-synonyms.
     """
 
+    #: module: The module used for functions used in compute functions
+    #: (such as ``sqrt``, ``sin``, ``cos``). Usually ``numpy``.
     lib: Module
 
     def _wrap_result(
@@ -523,7 +525,7 @@ class VectorProtocolPlanar(VectorProtocol):
         (i.e. not "antiparallel"; dot product is nearly ``abs(self) * abs(other)``).
 
         The ``tolerance`` is measured in units of $\cos(\Delta\alpha)$ where $\Delta\alpha$
-        is ``self.deltaangle(other)`.
+        is ``self.deltaangle(other)``.
         """
         raise AssertionError
 
@@ -535,7 +537,7 @@ class VectorProtocolPlanar(VectorProtocol):
         (i.e. dot product is nearly ``-abs(self) * abs(other)``).
 
         The ``tolerance`` is measured in units of $\cos(\Delta\alpha)$ where $\Delta\alpha$
-        is ``self.deltaangle(other)`.
+        is ``self.deltaangle(other)``.
         """
         raise AssertionError
 
@@ -547,7 +549,7 @@ class VectorProtocolPlanar(VectorProtocol):
         (i.e. dot product is nearly ``0``).
 
         The ``tolerance`` is measured in units of $\cos(\Delta\alpha)$ where $\Delta\alpha$
-        is ``self.deltaangle(other)`.
+        is ``self.deltaangle(other)``.
         """
         raise AssertionError
 
@@ -740,8 +742,8 @@ class VectorProtocolSpatial(VectorProtocolPlanar):
         """
         Rotates the vector(s) by three given angles: ``yaw``, ``pitch``, and ``roll``
         (in radians). These are Tait-Bryan angles often used for boats and planes
-        (see `this lesson <http://planning.cs.uiuc.edu/node102.html>`_ and
-        `this lesson <http://www.chrobotics.com/library/understanding-euler-angles>`_).
+        (see `this lesson <http://planning.cs.uiuc.edu/node102.html>`__ and
+        `this lesson <http://www.chrobotics.com/library/understanding-euler-angles>`__).
 
         This function is entirely equivalent to
 

--- a/src/vector/_methods.py
+++ b/src/vector/_methods.py
@@ -142,8 +142,6 @@ class VectorProtocol:
             vectors without momentum-synonyms.
     """
 
-    #: module: The module used for functions used in compute functions
-    #: (such as ``sqrt``, ``sin``, ``cos``). Usually ``numpy``.
     lib: Module
 
     def _wrap_result(

--- a/src/vector/_methods.py
+++ b/src/vector/_methods.py
@@ -383,7 +383,7 @@ class VectorProtocol:
 
         This method is equivalent to the ``==`` operator.
 
-        Typically, you'll want to check :doc:`vector._methods.VectorProtocol.isclose`
+        Typically, you'll want to check :meth:`vector._methods.VectorProtocol.isclose`
         to allow for numerical errors.
         """
         raise AssertionError
@@ -395,7 +395,7 @@ class VectorProtocol:
 
         This method is equivalent to the ``!=`` operator.
 
-        Typically, you'll want to check :doc:`vector._methods.VectorProtocol.isclose`
+        Typically, you'll want to check :meth:`vector._methods.VectorProtocol.isclose`
         to allow for numerical errors.
         """
         raise AssertionError
@@ -652,8 +652,8 @@ class VectorProtocolSpatial(VectorProtocolPlanar):
 
     def deltaR(self, other: "VectorProtocol") -> ScalarCollection:
         r"""
-        Sum in quadrature of :doc:`vector._methods.VectorProtocolPlanar.deltaphi`
-        and :doc:`vector._methods.VectorProtocolSpatial.deltaeta`:
+        Sum in quadrature of :meth:`vector._methods.VectorProtocolPlanar.deltaphi`
+        and :meth:`vector._methods.VectorProtocolSpatial.deltaeta`:
 
         $$\Delta R = \sqrt{\Delta\phi^2 + \Delta\eta^2}$$
         """
@@ -662,8 +662,8 @@ class VectorProtocolSpatial(VectorProtocolPlanar):
     def deltaR2(self, other: "VectorProtocol") -> ScalarCollection:
         r"""
         Square of the sum in quadrature of
-        :doc:`vector._methods.VectorProtocolPlanar.deltaphi` and
-        :doc:`vector._methods.VectorProtocolSpatial.deltaeta`:
+        :meth:`vector._methods.VectorProtocolPlanar.deltaphi` and
+        :meth:`vector._methods.VectorProtocolSpatial.deltaeta`:
 
         $$\Delta R^2 = \Delta\phi^2 + \Delta\eta^2$$
         """
@@ -718,7 +718,7 @@ class VectorProtocolSpatial(VectorProtocolPlanar):
           are proper Euler angles
         - ``"zxz"``, ``"xyx"``, ``"yzy"``, ``"zyz"``, ``"xzx"``, and ``"yxy"``
           are Tait-Bryan angles (see
-          :doc:`vector._methods.VectorProtocolSpatial.rotate_nautical`)
+          :meth:`vector._methods.VectorProtocolSpatial.rotate_nautical`)
 
         The names ``phi``, ``theta``, and ``psi`` agree with
         `Wikipedia's terminology <https://en.wikipedia.org/wiki/Euler_angles>`_,
@@ -899,8 +899,8 @@ class VectorProtocolLorentz(VectorProtocolSpatial):
 
     def deltaRapidityPhi(self, other: "VectorProtocol") -> ScalarCollection:
         r"""
-        Sum in quadrature of :doc:`vector._methods.VectorProtocolPlanar.deltaphi`
-        and the difference in :doc:`vector._methods.VectorProtocolLorentz.rapidity`
+        Sum in quadrature of :meth:`vector._methods.VectorProtocolPlanar.deltaphi`
+        and the difference in :attr:`vector._methods.VectorProtocolLorentz.rapidity`
         of the two vectors:
 
         $$\Delta R_{\mbox{rapidity}} = \sqrt{\Delta\phi^2 + \Delta \mbox{rapidity}^2}$$
@@ -910,8 +910,8 @@ class VectorProtocolLorentz(VectorProtocolSpatial):
     def deltaRapidityPhi2(self, other: "VectorProtocol") -> ScalarCollection:
         r"""
         Square of the sum in quadrature of
-        :doc:`vector._methods.VectorProtocolPlanar.deltaphi` and the difference in
-        :doc:`vector._methods.VectorProtocolLorentz.rapidity` of the two vectors:
+        :meth:`vector._methods.VectorProtocolPlanar.deltaphi` and the difference in
+        :attr:`vector._methods.VectorProtocolLorentz.rapidity` of the two vectors:
 
         $$\Delta R_{\mbox{rapidity}} = \Delta\phi^2 + \Delta \mbox{rapidity}^2$$
         """
@@ -941,7 +941,7 @@ class VectorProtocolLorentz(VectorProtocolSpatial):
 
             boost_beta3(p4.to_beta3())
 
-        where :doc:`vector._methods.VectorProtocolLorentz.to_beta3` converts a
+        where :meth:`vector._methods.VectorProtocolLorentz.to_beta3` converts a
         4D Lorentz vector into a 3D velocity (in which lightlike velocities have
         ``mag == 1``).
 
@@ -950,7 +950,7 @@ class VectorProtocolLorentz(VectorProtocolSpatial):
         since that negates the time component of ``v`` as well.
 
         To boost to the center-of-mass frame of a vector ``v``, use
-        :doc:`vector._methods.VectorProtocolLorentz.boostCM_of_p4`. For instance,
+        :meth:`vector._methods.VectorProtocolLorentz.boostCM_of_p4`. For instance,
         ``v.boostCM_of_p4(v)`` is guaranteed to have spatial components close to zero
         and a temporal component close to ``v.tau``.
         """
@@ -968,7 +968,7 @@ class VectorProtocolLorentz(VectorProtocolSpatial):
         since that negates the time component of ``v`` as well. On the other hand,
         ``v.boost_beta3(-(v.to_beta3()))`` *would* boost to the center-of-mass frame.
 
-        However, there's a function for that: :doc:`vector._methods.VectorProtocolLorentz.boostCM_of_beta3`
+        However, there's a function for that: :meth:`vector._methods.VectorProtocolLorentz.boostCM_of_beta3`
         is explicit about boosting to a center-of-mass (CM) frame and it handles the
         negative sign for you: ``v.boostCM_of_beta3(v.to_beta3())`` is guaranteed to
         have spatial components close to zero and a temporal component close to ``v.tau``.
@@ -980,18 +980,18 @@ class VectorProtocolLorentz(VectorProtocolSpatial):
         Boosts the vector or array of vectors using the 3D or 4D ``booster``.
 
         If ``booster`` is 3D, it is interpreted as a velocity (in which lightlike
-        velocities have ``mag == 1``) and :doc:`vector._methods.VectorProtocolLorentz.boost_beta3`
+        velocities have ``mag == 1``) and :meth:`vector._methods.VectorProtocolLorentz.boost_beta3`
         is called.
 
         If ``booster`` is 4D, it is interpreted as a Lorentz vector and
-        :doc:`vector._methods.VectorProtocolLorentz.boost_p4` is called.
+        :meth:`vector._methods.VectorProtocolLorentz.boost_p4` is called.
 
         Note that ``v.boost(v)`` does not boost into the center-of-mass (CM) frame
         of ``v``; it boosts *away* from its CM frame. Neither does ``v.boost(-v)``,
         since that negates the time component of ``v`` as well.
 
         To boost to the center-of-mass frame of a vector ``v``, use
-        :doc:`vector._methods.VectorProtocolLorentz.boostCM_of`. For instance,
+        :meth:`vector._methods.VectorProtocolLorentz.boostCM_of`. For instance,
         ``v.boostCM_of(v)`` is guaranteed to have spatial components close to zero
         and a temporal component close to ``v.tau``.
         """
@@ -1033,11 +1033,11 @@ class VectorProtocolLorentz(VectorProtocolSpatial):
         the 3D or 4D ``booster``.
 
         If ``booster`` is 3D, it is interpreted as a velocity (in which lightlike
-        velocities have ``mag == 1``) and :doc:`vector._methods.VectorProtocolLorentz.boostCM_of_beta3`
+        velocities have ``mag == 1``) and :meth:`vector._methods.VectorProtocolLorentz.boostCM_of_beta3`
         is called.
 
         If ``booster`` is 4D, it is interpreted as a Lorentz vector and
-        :doc:`vector._methods.VectorProtocolLorentz.boostCM_of_p4` is called.
+        :meth:`vector._methods.VectorProtocolLorentz.boostCM_of_p4` is called.
 
         Note that ``v.boostCM_of(v)`` is guaranteed to have spatial components close
         to zero and a temporal component close to ``v.tau``.
@@ -1126,11 +1126,11 @@ class VectorProtocolLorentz(VectorProtocolSpatial):
 
         The ``tolerance`` is in units of ``t`` and ``mag``. Note that
 
-        - the default ``tolerance`` for :doc:`vector._methods.VectorProtocolLorentz.is_timelike`
+        - the default ``tolerance`` for :meth:`vector._methods.VectorProtocolLorentz.is_timelike`
           is ``0``
-        - the default ``tolerance`` for :doc:`vector._methods.VectorProtocolLorentz.is_spacelike`
+        - the default ``tolerance`` for :meth:`vector._methods.VectorProtocolLorentz.is_spacelike`
           is ``0``
-        - the default ``tolerance`` for :doc:`vector._methods.VectorProtocolLorentz.is_lightlike`
+        - the default ``tolerance`` for :meth:`vector._methods.VectorProtocolLorentz.is_lightlike`
           is ``1e-5``
 
         If you want to use these methods to divide space-time into non-overlapping
@@ -1145,11 +1145,11 @@ class VectorProtocolLorentz(VectorProtocolSpatial):
 
         The ``tolerance`` is in units of ``t`` and ``mag``. Note that
 
-        - the default ``tolerance`` for :doc:`vector._methods.VectorProtocolLorentz.is_timelike`
+        - the default ``tolerance`` for :meth:`vector._methods.VectorProtocolLorentz.is_timelike`
           is ``0``
-        - the default ``tolerance`` for :doc:`vector._methods.VectorProtocolLorentz.is_spacelike`
+        - the default ``tolerance`` for :meth:`vector._methods.VectorProtocolLorentz.is_spacelike`
           is ``0``
-        - the default ``tolerance`` for :doc:`vector._methods.VectorProtocolLorentz.is_lightlike`
+        - the default ``tolerance`` for :meth:`vector._methods.VectorProtocolLorentz.is_lightlike`
           is ``1e-5``
 
         If you want to use these methods to divide space-time into non-overlapping
@@ -1164,11 +1164,11 @@ class VectorProtocolLorentz(VectorProtocolSpatial):
 
         The ``tolerance`` is in units of ``t`` and ``mag``. Note that
 
-        - the default ``tolerance`` for :doc:`vector._methods.VectorProtocolLorentz.is_timelike`
+        - the default ``tolerance`` for :meth:`vector._methods.VectorProtocolLorentz.is_timelike`
           is ``0``
-        - the default ``tolerance`` for :doc:`vector._methods.VectorProtocolLorentz.is_spacelike`
+        - the default ``tolerance`` for :meth:`vector._methods.VectorProtocolLorentz.is_spacelike`
           is ``0``
-        - the default ``tolerance`` for :doc:`vector._methods.VectorProtocolLorentz.is_lightlike`
+        - the default ``tolerance`` for :meth:`vector._methods.VectorProtocolLorentz.is_lightlike`
           is ``1e-5``
 
         If you want to use these methods to divide space-time into non-overlapping
@@ -1181,28 +1181,28 @@ class MomentumProtocolPlanar(VectorProtocolPlanar):
     @property
     def px(self) -> ScalarCollection:
         """
-        Momentum-synonym for :doc:`vector._methods.VectorProtocolPlanar.x`.
+        Momentum-synonym for :attr:`vector._methods.VectorProtocolPlanar.x`.
         """
         raise AssertionError
 
     @property
     def py(self) -> ScalarCollection:
         """
-        Momentum-synonym for :doc:`vector._methods.VectorProtocolPlanar.y`.
+        Momentum-synonym for :attr:`vector._methods.VectorProtocolPlanar.y`.
         """
         raise AssertionError
 
     @property
     def pt(self) -> ScalarCollection:
         """
-        Momentum-synonym for :doc:`vector._methods.VectorProtocolPlanar.rho`.
+        Momentum-synonym for :attr:`vector._methods.VectorProtocolPlanar.rho`.
         """
         raise AssertionError
 
     @property
     def pt2(self) -> ScalarCollection:
         """
-        Momentum-synonym for :doc:`vector._methods.VectorProtocolPlanar.rho2`.
+        Momentum-synonym for :attr:`vector._methods.VectorProtocolPlanar.rho2`.
         """
         raise AssertionError
 
@@ -1211,28 +1211,28 @@ class MomentumProtocolSpatial(VectorProtocolSpatial, MomentumProtocolPlanar):
     @property
     def pz(self) -> ScalarCollection:
         """
-        Momentum-synonym for :doc:`vector._methods.VectorProtocolSpatial.z`.
+        Momentum-synonym for :attr:`vector._methods.VectorProtocolSpatial.z`.
         """
         raise AssertionError
 
     @property
     def pseudorapidity(self) -> ScalarCollection:
         """
-        Momentum-synonym for :doc:`vector._methods.VectorProtocolSpatial.eta`.
+        Momentum-synonym for :attr:`vector._methods.VectorProtocolSpatial.eta`.
         """
         raise AssertionError
 
     @property
     def p(self) -> ScalarCollection:
         """
-        Momentum-synonym for :doc:`vector._methods.VectorProtocolSpatial.mag`.
+        Momentum-synonym for :attr:`vector._methods.VectorProtocolSpatial.mag`.
         """
         raise AssertionError
 
     @property
     def p2(self) -> ScalarCollection:
         """
-        Momentum-synonym for :doc:`vector._methods.VectorProtocolSpatial.mag2`.
+        Momentum-synonym for :attr:`vector._methods.VectorProtocolSpatial.mag2`.
         """
         raise AssertionError
 
@@ -1241,84 +1241,84 @@ class MomentumProtocolLorentz(VectorProtocolLorentz, MomentumProtocolSpatial):
     @property
     def E(self) -> ScalarCollection:
         """
-        Momentum-synonym for :doc:`vector._methods.VectorProtocolLorentz.t`.
+        Momentum-synonym for :attr:`vector._methods.VectorProtocolLorentz.t`.
         """
         raise AssertionError
 
     @property
     def e(self) -> ScalarCollection:
         """
-        Momentum-synonym for :doc:`vector._methods.VectorProtocolLorentz.t`.
+        Momentum-synonym for :attr:`vector._methods.VectorProtocolLorentz.t`.
         """
         raise AssertionError
 
     @property
     def energy(self) -> ScalarCollection:
         """
-        Momentum-synonym for :doc:`vector._methods.VectorProtocolLorentz.t`.
+        Momentum-synonym for :attr:`vector._methods.VectorProtocolLorentz.t`.
         """
         raise AssertionError
 
     @property
     def E2(self) -> ScalarCollection:
         """
-        Momentum-synonym for :doc:`vector._methods.VectorProtocolLorentz.t2`.
+        Momentum-synonym for :attr:`vector._methods.VectorProtocolLorentz.t2`.
         """
         raise AssertionError
 
     @property
     def e2(self) -> ScalarCollection:
         """
-        Momentum-synonym for :doc:`vector._methods.VectorProtocolLorentz.t2`.
+        Momentum-synonym for :attr:`vector._methods.VectorProtocolLorentz.t2`.
         """
         raise AssertionError
 
     @property
     def energy2(self) -> ScalarCollection:
         """
-        Momentum-synonym for :doc:`vector._methods.VectorProtocolLorentz.t2`.
+        Momentum-synonym for :attr:`vector._methods.VectorProtocolLorentz.t2`.
         """
         raise AssertionError
 
     @property
     def M(self) -> ScalarCollection:
         """
-        Momentum-synonym for :doc:`vector._methods.VectorProtocolLorentz.tau`.
+        Momentum-synonym for :attr:`vector._methods.VectorProtocolLorentz.tau`.
         """
         raise AssertionError
 
     @property
     def m(self) -> ScalarCollection:
         """
-        Momentum-synonym for :doc:`vector._methods.VectorProtocolLorentz.tau`.
+        Momentum-synonym for :attr:`vector._methods.VectorProtocolLorentz.tau`.
         """
         raise AssertionError
 
     @property
     def mass(self) -> ScalarCollection:
         """
-        Momentum-synonym for :doc:`vector._methods.VectorProtocolLorentz.tau`.
+        Momentum-synonym for :attr:`vector._methods.VectorProtocolLorentz.tau`.
         """
         raise AssertionError
 
     @property
     def M2(self) -> ScalarCollection:
         """
-        Momentum-synonym for :doc:`vector._methods.VectorProtocolLorentz.tau2`.
+        Momentum-synonym for :attr:`vector._methods.VectorProtocolLorentz.tau2`.
         """
         raise AssertionError
 
     @property
     def m2(self) -> ScalarCollection:
         """
-        Momentum-synonym for :doc:`vector._methods.VectorProtocolLorentz.tau2`.
+        Momentum-synonym for :attr:`vector._methods.VectorProtocolLorentz.tau2`.
         """
         raise AssertionError
 
     @property
     def mass2(self) -> ScalarCollection:
         """
-        Momentum-synonym for :doc:`vector._methods.VectorProtocolLorentz.tau2`.
+        Momentum-synonym for :attr:`vector._methods.VectorProtocolLorentz.tau2`.
         """
         raise AssertionError
 
@@ -1341,7 +1341,7 @@ class MomentumProtocolLorentz(VectorProtocolLorentz, MomentumProtocolSpatial):
     @property
     def transverse_energy(self) -> ScalarCollection:
         """
-        Synonym for :doc:`vector._methods.MomentumProtocolLorentz.Et`.
+        Synonym for :attr:`vector._methods.MomentumProtocolLorentz.Et`.
         """
         raise AssertionError
 
@@ -1364,7 +1364,7 @@ class MomentumProtocolLorentz(VectorProtocolLorentz, MomentumProtocolSpatial):
     @property
     def transverse_energy2(self) -> ScalarCollection:
         """
-        Synonym for :doc:`vector._methods.MomentumProtocolLorentz.Et2`.
+        Synonym for :attr:`vector._methods.MomentumProtocolLorentz.Et2`.
         """
         raise AssertionError
 
@@ -1387,7 +1387,7 @@ class MomentumProtocolLorentz(VectorProtocolLorentz, MomentumProtocolSpatial):
     @property
     def transverse_mass(self) -> ScalarCollection:
         """
-        Synonym for :doc:`vector._methods.MomentumProtocolLorentz.Mt`.
+        Synonym for :attr:`vector._methods.MomentumProtocolLorentz.Mt`.
         """
         raise AssertionError
 
@@ -1410,7 +1410,7 @@ class MomentumProtocolLorentz(VectorProtocolLorentz, MomentumProtocolSpatial):
     @property
     def transverse_mass2(self) -> ScalarCollection:
         """
-        Synonym for :doc:`vector._methods.MomentumProtocolLorentz.Mt2`.
+        Synonym for :attr:`vector._methods.MomentumProtocolLorentz.Mt2`.
         """
         raise AssertionError
 


### PR DESCRIPTION
Right now generating the docs throws several warnings. This PR aims to fix most of them!

## Warnings fixed
1. All the cross-references present in the documentation (in the form of `:doc: vector.x.y.z`) do not work. This PR fixes them!
2. Now, `mathjax3_config` (the latest mathjax version) is used instead of `mathjax_config` config.
3. Added some missing backticks.
4. Fixed identical-looking hyperlinks.

## Work left
Currently, the class variables present in the classes of `_methods` module render twice in the documentation. This is happening due to the presence of `:undoc-members:` in `_methods.rst`, which is required right now as several functions and classes lack docstring. Ideally, once the documentation is complete, `:undoc-members:` should be removed, solving this double documentation problem.

Or, the `rst` file can be programmed to ignore the double documentation in the following manner - 
```rst
vector.\_methods module
=======================

.. automodule:: vector._methods
   :members:
   :exclude-members: AzimuthalRhoPhi, AzimuthalXY, LongitudinalZ, LongitudinalTheta, LongitudinalEta, TemporalT, TemporalTau, VectorProtocol
   :undoc-members:
   :show-inheritance:
   :private-members:

   .. autoclass:: AzimuthalRhoPhi
      :ndoc-members:
      :exclude-members: rho, phi

   .. autoclass:: AzimuthalXY
      :undoc-members:
      :exclude-members: x, y

   .. autoclass:: LongitudinalZ
      :undoc-members:
      :exclude-members: Z

   .. autoclass:: LongitudinalTheta
      :undoc-members:
      :exclude-members: theta

   .. autoclass:: LongitudinalEta
      :undoc-members:
      :exclude-members: eta

   .. autoclass:: TemporalT
      :undoc-members:
      :exclude-members: t

   .. autoclass:: TemporalTau
      :undoc-members:
      :exclude-members: tau

   .. autoclass:: VectorProtocol
      :undoc-members:
      :exclude-members: lib , ProjectionClass2D, ProjectionClass3D, ProjectionClass4D
```

Should I edit the `rst` file, or should we wait till the documentation is complete and then remove `:undoc-members:` from the file?

## Example of double documentation

![image](https://user-images.githubusercontent.com/74055102/169694552-d8275623-368a-427d-8360-33f5051aaf14.png)

## References
- https://stackoverflow.com/questions/50546154/documenting-class-attributes-with-type-annotations
- https://stackoverflow.com/questions/64796801/documenting-class-level-variables-in-python