### PR TITLE
chore: fix conda badge and update dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,3 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    ignore:
-      # Official actions have moving tags like v1
-      # that are used, so they don't need updates here
-      - dependency-name: "actions/*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: 3.x
     - uses: pre-commit/action@v3.0.0
       with:
         extra_args: --hook-stage manual check-manifest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
     - uses: pre-commit/action@v3.0.0
       with:
         extra_args: --hook-stage manual check-manifest

--- a/README.md
+++ b/README.md
@@ -623,8 +623,8 @@ Support for this work was provided by the National Science Foundation cooperativ
 [black-link]:               https://github.com/psf/black
 [codecov-badge]:            https://codecov.io/gh/scikit-hep/vector/branch/main/graph/badge.svg?token=YBv60ueORQ
 [codecov-link]:             https://codecov.io/gh/scikit-hep/vector
-[conda-version]:            https://img.shields.io/conda/vn/conda-forge/decaylanguage.svg
-[conda-link]:               https://github.com/conda-forge/decaylanguage-feedstock
+[conda-version]:            https://img.shields.io/conda/vn/conda-forge/vector.svg
+[conda-link]:               https://github.com/conda-forge/vector-feedstock
 [github-discussions-badge]: https://img.shields.io/static/v1?label=Discussions&message=Ask&color=blue&logo=github
 [github-discussions-link]:  https://github.com/scikit-hep/vector/discussions
 [gitter-badge]:             https://badges.gitter.im/Scikit-HEP/vector.svg

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -110,8 +110,8 @@ The API reference details the functionality of each ``class`` and ``function`` p
    :target: https://pypi.org/project/vector/
 .. |PyPI version| image:: https://badge.fury.io/py/vector.svg
    :target: https://pypi.org/project/vector/
-.. |Conda latest releasetatus| image:: https://img.shields.io/conda/vn/conda-forge/decaylanguage.svg
-   :target: https://github.com/conda-forge/decaylanguage-feedstock
+.. |Conda latest releasetatus| image:: https://img.shields.io/conda/vn/conda-forge/vector.svg
+   :target: https://github.com/conda-forge/vector-feedstock
 .. |DOI| image:: https://zenodo.org/badge/DOI/10.5281/zenodo.5942083.svg
    :target: https://doi.org/10.5281/zenodo.5942082
 .. |Scikit-HEP| image:: https://scikit-hep.org/assets/images/Scikit--HEP-Project-blue.svg


### PR DESCRIPTION
- Currently, the conda badge points towards decay language
- Update `dependabot.yml` to catch next major versions
- Update `setup-python` with python version for `v4`