### PR TITLE
docs: render module level docstrings in documentation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -86,8 +86,6 @@ API reference
 -------------
 The API reference details the functionality of each ``class`` and ``function`` present in ``vector``'s codebase.
 
-**Note**: Adding missing docstrings is still in progress.
-
 .. toctree::
    :maxdepth: 8
    :caption: API Reference

--- a/src/vector/_compute/lorentz/Et2.py
+++ b/src/vector/_compute/lorentz/Et2.py
@@ -3,14 +3,13 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     @property
     Lorentz.Et2(self)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/lorentz/Mt.py
+++ b/src/vector/_compute/lorentz/Mt.py
@@ -3,14 +3,13 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     @property
     Lorentz.Mt(self)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/lorentz/Mt2.py
+++ b/src/vector/_compute/lorentz/Mt2.py
@@ -3,14 +3,13 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     @property
     Lorentz.Mt2(self)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/lorentz/add.py
+++ b/src/vector/_compute/lorentz/add.py
@@ -3,13 +3,12 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     Lorentz.add(self, other)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/lorentz/beta.py
+++ b/src/vector/_compute/lorentz/beta.py
@@ -3,14 +3,13 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     @property
     Lorentz.beta(self)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/lorentz/boostX_beta.py
+++ b/src/vector/_compute/lorentz/boostX_beta.py
@@ -3,13 +3,12 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     Lorentz.boostX(self, beta=...)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/lorentz/boostX_gamma.py
+++ b/src/vector/_compute/lorentz/boostX_gamma.py
@@ -3,13 +3,12 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     Lorentz.boostX(self, gamma=)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/lorentz/boostY_beta.py
+++ b/src/vector/_compute/lorentz/boostY_beta.py
@@ -3,13 +3,12 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     Lorentz.boostY(self, beta=...)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/lorentz/boostY_gamma.py
+++ b/src/vector/_compute/lorentz/boostY_gamma.py
@@ -3,13 +3,12 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     Lorentz.boostY(self, gamma=...)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/lorentz/boostZ_beta.py
+++ b/src/vector/_compute/lorentz/boostZ_beta.py
@@ -3,13 +3,12 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     Lorentz.boostZ(self, beta=...)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/lorentz/boostZ_gamma.py
+++ b/src/vector/_compute/lorentz/boostZ_gamma.py
@@ -3,13 +3,12 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     Lorentz.boostZ(self, gamma=...)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/lorentz/boost_beta3.py
+++ b/src/vector/_compute/lorentz/boost_beta3.py
@@ -3,8 +3,6 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
@@ -16,6 +14,7 @@ or
 
     Lorentz.boost(self, beta3=...)
 """
+import typing
 
 import numpy
 
@@ -202,20 +201,18 @@ dispatch_map = {
         LongitudinalZ,
         TemporalTau,
     ),
-    (
+    (AzimuthalXY, LongitudinalZ, TemporalT, AzimuthalXY, LongitudinalTheta,): (
+        cartesian_t_xy_theta,
         AzimuthalXY,
         LongitudinalZ,
         TemporalT,
-        AzimuthalXY,
-        LongitudinalTheta,
-    ): (cartesian_t_xy_theta, AzimuthalXY, LongitudinalZ, TemporalT),
-    (
+    ),
+    (AzimuthalXY, LongitudinalZ, TemporalTau, AzimuthalXY, LongitudinalTheta,): (
+        cartesian_tau_xy_theta,
         AzimuthalXY,
         LongitudinalZ,
         TemporalTau,
-        AzimuthalXY,
-        LongitudinalTheta,
-    ): (cartesian_tau_xy_theta, AzimuthalXY, LongitudinalZ, TemporalTau),
+    ),
     (AzimuthalXY, LongitudinalZ, TemporalT, AzimuthalXY, LongitudinalEta): (
         cartesian_t_xy_eta,
         AzimuthalXY,
@@ -228,48 +225,42 @@ dispatch_map = {
         LongitudinalZ,
         TemporalTau,
     ),
-    (
+    (AzimuthalXY, LongitudinalZ, TemporalT, AzimuthalRhoPhi, LongitudinalZ,): (
+        cartesian_t_rhophi_z,
         AzimuthalXY,
         LongitudinalZ,
         TemporalT,
-        AzimuthalRhoPhi,
-        LongitudinalZ,
-    ): (cartesian_t_rhophi_z, AzimuthalXY, LongitudinalZ, TemporalT),
-    (
+    ),
+    (AzimuthalXY, LongitudinalZ, TemporalTau, AzimuthalRhoPhi, LongitudinalZ,): (
+        cartesian_tau_rhophi_z,
         AzimuthalXY,
         LongitudinalZ,
         TemporalTau,
-        AzimuthalRhoPhi,
-        LongitudinalZ,
-    ): (cartesian_tau_rhophi_z, AzimuthalXY, LongitudinalZ, TemporalTau),
-    (
+    ),
+    (AzimuthalXY, LongitudinalZ, TemporalT, AzimuthalRhoPhi, LongitudinalTheta,): (
+        cartesian_t_rhophi_theta,
         AzimuthalXY,
         LongitudinalZ,
         TemporalT,
-        AzimuthalRhoPhi,
-        LongitudinalTheta,
-    ): (cartesian_t_rhophi_theta, AzimuthalXY, LongitudinalZ, TemporalT),
-    (
+    ),
+    (AzimuthalXY, LongitudinalZ, TemporalTau, AzimuthalRhoPhi, LongitudinalTheta,): (
+        cartesian_tau_rhophi_theta,
         AzimuthalXY,
         LongitudinalZ,
         TemporalTau,
-        AzimuthalRhoPhi,
-        LongitudinalTheta,
-    ): (cartesian_tau_rhophi_theta, AzimuthalXY, LongitudinalZ, TemporalTau),
-    (
+    ),
+    (AzimuthalXY, LongitudinalZ, TemporalT, AzimuthalRhoPhi, LongitudinalEta,): (
+        cartesian_t_rhophi_eta,
         AzimuthalXY,
         LongitudinalZ,
         TemporalT,
-        AzimuthalRhoPhi,
-        LongitudinalEta,
-    ): (cartesian_t_rhophi_eta, AzimuthalXY, LongitudinalZ, TemporalT),
-    (
+    ),
+    (AzimuthalXY, LongitudinalZ, TemporalTau, AzimuthalRhoPhi, LongitudinalEta,): (
+        cartesian_tau_rhophi_eta,
         AzimuthalXY,
         LongitudinalZ,
         TemporalTau,
-        AzimuthalRhoPhi,
-        LongitudinalEta,
-    ): (cartesian_tau_rhophi_eta, AzimuthalXY, LongitudinalZ, TemporalTau),
+    ),
 }
 
 

--- a/src/vector/_compute/lorentz/boost_p4.py
+++ b/src/vector/_compute/lorentz/boost_p4.py
@@ -3,8 +3,6 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
@@ -16,6 +14,7 @@ or
 
     Lorentz.boost(self, p4=...)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/lorentz/deltaRapidityPhi.py
+++ b/src/vector/_compute/lorentz/deltaRapidityPhi.py
@@ -3,13 +3,12 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     Spatial.deltaRapidityPhi(self, other)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/lorentz/deltaRapidityPhi2.py
+++ b/src/vector/_compute/lorentz/deltaRapidityPhi2.py
@@ -3,13 +3,12 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     Spatial.deltaRapidityPhi2(self, other)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/lorentz/dot.py
+++ b/src/vector/_compute/lorentz/dot.py
@@ -3,13 +3,12 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     Lorentz.dot(self, other)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/lorentz/equal.py
+++ b/src/vector/_compute/lorentz/equal.py
@@ -3,13 +3,12 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     Lorentz.equal(self, other)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/lorentz/gamma.py
+++ b/src/vector/_compute/lorentz/gamma.py
@@ -3,14 +3,13 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     @property
     Lorentz.gamma(self)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/lorentz/is_lightlike.py
+++ b/src/vector/_compute/lorentz/is_lightlike.py
@@ -3,13 +3,12 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     Lorentz.is_lightlike(self, tolerance=...)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/lorentz/is_spacelike.py
+++ b/src/vector/_compute/lorentz/is_spacelike.py
@@ -3,13 +3,12 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     Lorentz.is_spacelike(self, tolerance=...)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/lorentz/is_timelike.py
+++ b/src/vector/_compute/lorentz/is_timelike.py
@@ -3,13 +3,12 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     Lorentz.is_timelike(self, tolerance=...)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/lorentz/isclose.py
+++ b/src/vector/_compute/lorentz/isclose.py
@@ -3,13 +3,12 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     Lorentz.isclose(self, rtol=..., atol=..., equal_nan=...)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/lorentz/not_equal.py
+++ b/src/vector/_compute/lorentz/not_equal.py
@@ -3,13 +3,12 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     Lorentz.not_equal(self, other)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/lorentz/rapidity.py
+++ b/src/vector/_compute/lorentz/rapidity.py
@@ -3,14 +3,13 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     @property
     Lorentz.rapidity(self)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/lorentz/scale.py
+++ b/src/vector/_compute/lorentz/scale.py
@@ -3,13 +3,12 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     Lorentz.scale(self, factor)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/lorentz/subtract.py
+++ b/src/vector/_compute/lorentz/subtract.py
@@ -3,13 +3,12 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     Lorentz.subtract(self, other)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/lorentz/t.py
+++ b/src/vector/_compute/lorentz/t.py
@@ -3,14 +3,13 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     @property
     Lorentz.t(self)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/lorentz/t2.py
+++ b/src/vector/_compute/lorentz/t2.py
@@ -3,14 +3,13 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     @property
     Lorentz.t2(self)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/lorentz/tau.py
+++ b/src/vector/_compute/lorentz/tau.py
@@ -3,14 +3,13 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     @property
     Lorentz.tau(self)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/lorentz/tau2.py
+++ b/src/vector/_compute/lorentz/tau2.py
@@ -3,14 +3,13 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     @property
     Lorentz.tau2(self)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/lorentz/to_beta3.py
+++ b/src/vector/_compute/lorentz/to_beta3.py
@@ -3,13 +3,12 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     Lorentz.to_beta3(self)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/lorentz/transform4D.py
+++ b/src/vector/_compute/lorentz/transform4D.py
@@ -3,8 +3,6 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
@@ -12,6 +10,7 @@ import typing
 
 where ``obj`` has ``obj["xx"]``, ``obj["xy"]``, etc.
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/lorentz/unit.py
+++ b/src/vector/_compute/lorentz/unit.py
@@ -3,13 +3,12 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     Lorentz.unit(self)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/planar/add.py
+++ b/src/vector/_compute/planar/add.py
@@ -3,13 +3,12 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     Planar.add(self, other)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/planar/deltaphi.py
+++ b/src/vector/_compute/planar/deltaphi.py
@@ -2,14 +2,13 @@
 #
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
-
-import typing
-
 """
 .. code-block:: python
 
     Planar.deltaphi(self, other)
 """
+
+import typing
 
 import numpy
 

--- a/src/vector/_compute/planar/dot.py
+++ b/src/vector/_compute/planar/dot.py
@@ -3,13 +3,12 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     Planar.dot(self, other)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/planar/equal.py
+++ b/src/vector/_compute/planar/equal.py
@@ -3,13 +3,12 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     Planar.equal(self, other)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/planar/is_antiparallel.py
+++ b/src/vector/_compute/planar/is_antiparallel.py
@@ -3,13 +3,12 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     Planar.is_antiparallel(self, other, tolerance=...)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/planar/is_parallel.py
+++ b/src/vector/_compute/planar/is_parallel.py
@@ -3,13 +3,12 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     Planar.is_parallel(self, other, tolerance=...)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/planar/is_perpendicular.py
+++ b/src/vector/_compute/planar/is_perpendicular.py
@@ -3,13 +3,12 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     Planar.is_perpendicular(self, other, tolerance=...)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/planar/isclose.py
+++ b/src/vector/_compute/planar/isclose.py
@@ -3,13 +3,12 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     Planar.isclose(self, other, rtol=..., atol=..., equal_nan=...)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/planar/not_equal.py
+++ b/src/vector/_compute/planar/not_equal.py
@@ -3,13 +3,12 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     Planar.not_equal(self, other)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/planar/phi.py
+++ b/src/vector/_compute/planar/phi.py
@@ -3,14 +3,13 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     @property
     Planar.phi(self)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/planar/rho.py
+++ b/src/vector/_compute/planar/rho.py
@@ -3,14 +3,13 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     @property
     Planar.rho(self)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/planar/rho2.py
+++ b/src/vector/_compute/planar/rho2.py
@@ -3,14 +3,13 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     @property
     Planar.rho2(self)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/planar/rotateZ.py
+++ b/src/vector/_compute/planar/rotateZ.py
@@ -3,13 +3,12 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     Planar.rotateZ(self, angle)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/planar/scale.py
+++ b/src/vector/_compute/planar/scale.py
@@ -3,13 +3,12 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     Planar.scale(self, factor)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/planar/subtract.py
+++ b/src/vector/_compute/planar/subtract.py
@@ -3,13 +3,12 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     Planar.subtract(self, other)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/planar/transform2D.py
+++ b/src/vector/_compute/planar/transform2D.py
@@ -3,8 +3,6 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
@@ -12,6 +10,7 @@ import typing
 
 where ``obj`` has ``obj["xx"]``, ``obj["xy"]``, etc.
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/planar/unit.py
+++ b/src/vector/_compute/planar/unit.py
@@ -3,13 +3,12 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     Planar.unit(self)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/planar/x.py
+++ b/src/vector/_compute/planar/x.py
@@ -3,14 +3,13 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     @property
     Planar.x(self)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/planar/y.py
+++ b/src/vector/_compute/planar/y.py
@@ -3,14 +3,13 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     @property
     Planar.y(self)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/spatial/add.py
+++ b/src/vector/_compute/spatial/add.py
@@ -3,13 +3,12 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     Spatial.add(self, other)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/spatial/costheta.py
+++ b/src/vector/_compute/spatial/costheta.py
@@ -3,14 +3,13 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     @property
     Spatial.costheta(self)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/spatial/cottheta.py
+++ b/src/vector/_compute/spatial/cottheta.py
@@ -3,14 +3,13 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     @property
     Spatial.cottheta(self)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/spatial/cross.py
+++ b/src/vector/_compute/spatial/cross.py
@@ -3,8 +3,6 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
@@ -13,6 +11,7 @@ import typing
 Note that this returns a 3D vector even for 4D inputs. The ``None`` at the end
 of the return signature indicates termination.
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/spatial/deltaR.py
+++ b/src/vector/_compute/spatial/deltaR.py
@@ -3,13 +3,12 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     Spatial.deltaR(self, other)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/spatial/deltaR2.py
+++ b/src/vector/_compute/spatial/deltaR2.py
@@ -3,13 +3,12 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     Spatial.deltaR2(self, other)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/spatial/deltaangle.py
+++ b/src/vector/_compute/spatial/deltaangle.py
@@ -3,13 +3,12 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     Spatial.deltaangle(self, other)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/spatial/deltaeta.py
+++ b/src/vector/_compute/spatial/deltaeta.py
@@ -3,13 +3,12 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     Spatial.deltaeta(self, other)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/spatial/dot.py
+++ b/src/vector/_compute/spatial/dot.py
@@ -3,13 +3,12 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     Spatial.dot(self, other)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/spatial/equal.py
+++ b/src/vector/_compute/spatial/equal.py
@@ -3,13 +3,12 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     Spatial.equal(self, other)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/spatial/eta.py
+++ b/src/vector/_compute/spatial/eta.py
@@ -3,15 +3,14 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-from math import inf, nan
-
 """
 .. code-block:: python
 
     @property
     Spatial.eta(self)
 """
+import typing
+from math import inf, nan
 
 import numpy
 

--- a/src/vector/_compute/spatial/is_antiparallel.py
+++ b/src/vector/_compute/spatial/is_antiparallel.py
@@ -3,13 +3,12 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     Spatial.is_antiparallel(self, other, tolerance=...)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/spatial/is_parallel.py
+++ b/src/vector/_compute/spatial/is_parallel.py
@@ -3,13 +3,12 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     Spatial.is_parallel(self, other, tolerance=...)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/spatial/is_perpendicular.py
+++ b/src/vector/_compute/spatial/is_perpendicular.py
@@ -3,13 +3,12 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     Spatial.is_perpendicular(self, other, tolerance=...)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/spatial/isclose.py
+++ b/src/vector/_compute/spatial/isclose.py
@@ -3,13 +3,12 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     Spatial.isclose(self, other, rtol=..., atol=..., equal_nan=...)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/spatial/mag.py
+++ b/src/vector/_compute/spatial/mag.py
@@ -3,14 +3,13 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     @property
     Spatial.mag(self)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/spatial/mag2.py
+++ b/src/vector/_compute/spatial/mag2.py
@@ -3,14 +3,13 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     @property
     Spatial.mag2(self)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/spatial/not_equal.py
+++ b/src/vector/_compute/spatial/not_equal.py
@@ -3,13 +3,12 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     Spatial.not_equal(self, other)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/spatial/rotateX.py
+++ b/src/vector/_compute/spatial/rotateX.py
@@ -3,13 +3,12 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     Spatial.rotateX(self, angle)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/spatial/rotateY.py
+++ b/src/vector/_compute/spatial/rotateY.py
@@ -3,13 +3,12 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     Spatial.rotateY(self, angle)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/spatial/rotate_axis.py
+++ b/src/vector/_compute/spatial/rotate_axis.py
@@ -3,13 +3,12 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     Spatial.rotate_axis(self, axis, angle)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/spatial/rotate_euler.py
+++ b/src/vector/_compute/spatial/rotate_euler.py
@@ -3,13 +3,12 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     Spatial.rotate_euler(self, phi, theta, psi, order=...)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/spatial/rotate_quaternion.py
+++ b/src/vector/_compute/spatial/rotate_quaternion.py
@@ -3,13 +3,12 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     Spatial.rotate_quaternion(self, u, i, j, k)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/spatial/scale.py
+++ b/src/vector/_compute/spatial/scale.py
@@ -3,13 +3,12 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     Spatial.scale(self, factor)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/spatial/subtract.py
+++ b/src/vector/_compute/spatial/subtract.py
@@ -3,13 +3,12 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     Spatial.subtract(self, angle)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/spatial/theta.py
+++ b/src/vector/_compute/spatial/theta.py
@@ -3,14 +3,13 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     @property
     Spatial.theta(self)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/spatial/transform3D.py
+++ b/src/vector/_compute/spatial/transform3D.py
@@ -3,8 +3,6 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
@@ -12,6 +10,7 @@ import typing
 
 where ``obj` has ``obj["xx"]``, ``obj["xy"]``, etc.
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/spatial/unit.py
+++ b/src/vector/_compute/spatial/unit.py
@@ -3,13 +3,12 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     Spatial.unit(self)
 """
+import typing
 
 import numpy
 

--- a/src/vector/_compute/spatial/z.py
+++ b/src/vector/_compute/spatial/z.py
@@ -3,14 +3,13 @@
 # Distributed under the 3-clause BSD license, see accompanying file LICENSE
 # or https://github.com/scikit-hep/vector for details.
 
-import typing
-
 """
 .. code-block:: python
 
     @property
     Spatial.z(self)
 """
+import typing
 
 import numpy
 


### PR DESCRIPTION
This PR moves the module level docstrings above the imports which makes them render nicely in the sphinx docs.