### PR TITLE
chore: add `codecov.yml`

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,3 @@
+codecov:
+  notify:
+    after_n_builds: 4


### PR DESCRIPTION
`Codecov` will now only respond once all 4 builds pass.