### PR TITLE
docs: Add CITATION.cff Citation File Format file

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,26 @@
+cff-version: 1.2.0
+message: "Please cite the following works when using this software."
+type: software
+title: "vector"
+abstract: "Vector is a Python library for 2D, 3D, and Lorentz vectors, especially arrays of vectors, to solve common physics problems in a NumPy-like way."
+authors:
+- family-names: "Schreiner"
+  given-names: "Henry"
+  orcid: "https://orcid.org/0000-0002-7833-783X"
+  affiliation: "Princeton University"
+- family-names: "Pivarski"
+  given-names: "Jim"
+  orcid: "https://orcid.org/0000-0002-6649-343X"
+  affiliation: "Princeton University"
+- family-names: "Chopra"
+  given-names: "Saransh"
+  orcid: "https://orcid.org/0000-0003-3046-7675"
+  affiliation: "University of Delhi"
+doi: 10.5281/zenodo.5942082
+repository-code: "https://github.com/scikit-hep/vector"
+url: "https://vector.readthedocs.io/"
+keywords:
+  - python
+  - vectors
+  - scikit-hep
+license: "BSD-3-Clause"


### PR DESCRIPTION
Resolves #238

Add Citation File Format file to repo to get repository cite button on GitHub and citation support on Zenodo.
   - c.f. https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-citation-files

The schema used is validated by [`cffconvert`](https://pypi.org/project/cffconvert/)

```console
$ pipx install cffconvert
$ cffconvert --validate --infile CITATION.cff 
Citation metadata are valid according to schema version 1.2.0.
```