### PR TITLE
fix: `vector.arr` should construct `NumPy` vectors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Test package with awkward v1.x
         run: python -m pytest -ra --cov=vector tests/
 
-      - name: Use awkward v1.9.0 for v2 support
+      - name: Use awkward v1.10.x for v2 support
         run: python -m pip install -U --pre "awkward<2"
 
       - name: Test package with awkward._v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,8 +63,6 @@ repos:
     rev: v2.2.1
     hooks:
       - id: codespell
-        args: ["-L", "hist,nd,circularly,ba"]
-        exclude: ^(notebooks/xarray.ipynb|notebooks/BoostHistogramHandsOn.ipynb)$
 
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: "v3.0.0-alpha.0"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,8 +3,10 @@
 ## Unreleased
 
 - chore: test on `awkard v1.10.0` and add cov to `noxfile` [#256][]
+- `vector.arr` is now an alias for `vector.array` (`NumPy` vectors) [#254][]
 
 [#256]: https://github.com/scikit-hep/vector/pull/256
+[#254]: https://github.com/scikit-hep/vector/pull/254
 
 ## Version 0.10
 

--- a/src/vector/__init__.py
+++ b/src/vector/__init__.py
@@ -33,7 +33,6 @@ from vector._methods import (
     dim,
 )
 from vector.backends.awkward_constructors import Array as Array
-from vector.backends.awkward_constructors import Array as arr
 from vector.backends.awkward_constructors import Array as awk
 from vector.backends.awkward_constructors import zip
 from vector.backends.numpy import (
@@ -44,8 +43,9 @@ from vector.backends.numpy import (
     VectorNumpy2D,
     VectorNumpy3D,
     VectorNumpy4D,
-    array,
 )
+from vector.backends.numpy import array
+from vector.backends.numpy import array as arr
 from vector.backends.object import (
     MomentumObject2D,
     MomentumObject3D,


### PR DESCRIPTION
Currently, all the examples located in `vector`, as well as the introduction to constructors here - https://github.com/scikit-hep/vector#constructing-a-vector-or-an-array-of-vectors - point to the fact that `vector.arr` should construct `NumPy` vectors. This also seems logical (`Array` -> `awk` , `array` -> `arr`), and is most probably not wrong in the examples.