### PR TITLE
Add papermill as dependancy 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,10 +67,10 @@ docs = [
   "sphinx_copybutton",
 ]
 test = [
+  "papermill>=2.4",
   "pytest>=6",
   "pytest-cov>=3",
   "xdoctest>=1",
-  "papermill>=2.4.0",
 ]
 test-extras = [
   "spark-parser",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ test = [
   "pytest>=6",
   "pytest-cov>=3",
   "xdoctest>=1",
+  "papermill>=2.4.0",
 ]
 test-extras = [
   "spark-parser",

--- a/src/vector/_methods.py
+++ b/src/vector/_methods.py
@@ -4,6 +4,7 @@
 # or https://github.com/scikit-hep/vector for details.
 
 from __future__ import annotations
+from argparse import ArgumentError
 
 import typing
 from contextlib import suppress
@@ -1698,11 +1699,23 @@ class Vector2D(Vector, VectorProtocolPlanar):
     def to_Vector2D(self) -> VectorProtocolPlanar:
         return self
 
-    def to_Vector3D(self) -> VectorProtocolSpatial:
+    def to_Vector3D(self, **coord) -> VectorProtocolSpatial:
+        if len(coord) > 1:
+            raise ArgumentError(coord, "can be `z`, `theta`, or `eta`")
+
+        coord_type, coord_value = list(coord.keys())[0], list(coord.values())[0]
+
+        if coord_type == "z":
+            l_type = LongitudinalZ
+        elif coord_type == "eta":
+            l_type = LongitudinalEta
+        elif coord_type == "theta":
+            l_type = LongitudinalTheta
+
         return self._wrap_result(
             type(self),
-            self.azimuthal.elements + (0,),
-            [_aztype(self), LongitudinalZ, None],
+            self.azimuthal.elements + (coord_value,),
+            [_aztype(self), l_type, None],
             1,
         )
 

--- a/src/vector/_methods.py
+++ b/src/vector/_methods.py
@@ -4,9 +4,9 @@
 # or https://github.com/scikit-hep/vector for details.
 
 from __future__ import annotations
-from argparse import ArgumentError
 
 import typing
+from argparse import ArgumentError
 from contextlib import suppress
 
 import vector


### PR DESCRIPTION
## Description

**Kindly take a look at [CONTRIBUTING.md](https://github.com/scikit-hep/vector/blob/main/.github/CONTRIBUTING.md).**

I was working on another issue and found out that the new workflow file `notebooks.yml` uses papermill for parameterizing and executing Jupyter Notebooks. 

## Checklist

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't any other open Pull Request for the required change ?
- [x] Does your submission pass pre-commit? (`$ pre-commit run --all-files` or `$ nox -s lint`)
- [x] Does your submission pass tests? (`$ pytest` or `$ nox -s tests`)
- [x] Does the documentation build with your changes? (`$ cd docs; make clean; make html` or `$ nox -s docs`)
- [x] Does your submission pass doctests? (`$ xdoctest ./src/vector` or `$ nox -s doctests`)

## Before Merging

- [ ] Summarize commit messages into a brief review of the Pull request.
