### PR TITLE
Fix missing backslash in latex for readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,7 +550,7 @@ The (current) list of properties and methods is:
 - `tau` (`M`, `mass`): see note above
 - `tau2` (`M2`, `mass2`)
 - `beta`: scalar(s) between $0$ (inclusive) and $1$ (exclusive, unless the vector components are infinite)
-- `deltaRapidityPhi`: $Delta R_{\mbox{rapidity}} = \Delta\phi^2 + \Delta \mbox{rapidity}^2$
+- `deltaRapidityPhi`: $\Delta R_{\mbox{rapidity}} = \Delta\phi^2 + \Delta \mbox{rapidity}^2$
 - `deltaRapidityPhi2`: the above, squared
 - `gamma`: scalar(s) between $1$ (inclusive) and $\infty$
 - `rapidity`: scalar(s) between $0$ (inclusive) and $\infty$


### PR DESCRIPTION
-------

## Description

While checking the available methods in the github readme I noticed that one $Delta$ didn't render properly as $\Delta$ so I decided to quickly fix add the missing backslash. On my fork this renders properly now. For testing I just ran pre-commit to check that I my editor didn't do any weird whitespace changes that I didn't notice. But I didn't run the unit tests or the doctests as I didn't change anything in the code. Should I?

## Checklist

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't any other open Pull Request for the required change ?
- [x] Does your submission pass pre-commit? (`$ pre-commit run --all-files` or `$ nox -s lint`)
- [ ] Does your submission pass tests? (`$ pytest` or `$ nox -s tests`)
- [ ] Does the documentation build with your changes? (`$ cd docs; make clean; make html` or `$ nox -s docs`)
- [ ] Does your submission pass doctests? (`$ xdoctest ./src/vector` or `$ nox -s doctests`)

## Before Merging

- [x] Summarize commit messages into a brief review of the Pull request.