### PR TITLE
fix: better elif conditions for obj __init__ methods

### DIFF
--- a/src/vector/backends/object.py
+++ b/src/vector/backends/object.py
@@ -1065,7 +1065,7 @@ class VectorObject3D(VectorObject, Spatial, Vector3D):
         if not kwargs and azimuthal is not None and longitudinal is not None:
             self.azimuthal = azimuthal
             self.longitudinal = longitudinal
-        elif kwargs and azimuthal is None:
+        elif kwargs and azimuthal is None and longitudinal is None:
             if set(kwargs) == {"x", "y", "z"}:
                 self.azimuthal = AzimuthalObjectXY(kwargs["x"], kwargs["y"])
                 self.longitudinal = LongitudinalObjectZ(kwargs["z"])
@@ -1739,7 +1739,7 @@ class VectorObject4D(VectorObject, Lorentz, Vector4D):
             self.azimuthal = azimuthal
             self.longitudinal = longitudinal
             self.temporal = temporal
-        elif kwargs and azimuthal is None:
+        elif kwargs and azimuthal is None and longitudinal is None and temporal is None:
             if set(kwargs) == {"x", "y", "z", "t"}:
                 self.azimuthal = AzimuthalObjectXY(kwargs["x"], kwargs["y"])
                 self.longitudinal = LongitudinalObjectZ(kwargs["z"])


### PR DESCRIPTION
## Description

The `elif` condition missed checking for the `longitudinal` and `temporal` arguments.

## Checklist

- [ ] Have you followed the guidelines in our Contributing document?
- [ ] Have you checked to ensure there aren't any other open Pull Requests for the required change?
- [ ] Does your submission pass pre-commit? (`$ pre-commit run --all-files` or `$ nox -s lint`)
- [ ] Does your submission pass tests? (`$ pytest` or `$ nox -s tests`)
- [ ] Does the documentation build with your changes? (`$ cd docs; make clean; make html` or `$ nox -s docs`)
- [ ] Does your submission pass the doctests? (`$ xdoctest ./src/vector` or `$ nox -s doctests`)

## Before Merging

- [ ] Summarize the commit messages into a brief review of the Pull request.
