### PR TITLE
chore: remove Python 3.7 support

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -28,6 +28,11 @@ jobs:
     needs: [dist]
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'
+    environment:
+      name: pypi
+      url: https://pypi.org/p/vector
+    permissions:
+      id-token: write
 
     steps:
       - uses: actions/download-artifact@v3
@@ -35,7 +40,4 @@ jobs:
           name: artifact
           path: dist
 
-      - uses: pypa/gh-action-pypi-publish@v1.8.6
-        with:
-          user: __token__
-          password: ${{ secrets.pypi_password }}
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"
@@ -64,7 +63,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"
@@ -96,7 +94,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 [![LICENSE][license-badge]][license-link]
 [![Scikit-HEP][sk-badge]][sk-link]
 
-Vector is a Python 3.7+ library for 2D, 3D, and [Lorentz vectors](https://en.wikipedia.org/wiki/Special_relativity#Physics_in_spacetime), especially _arrays of vectors_, to solve common physics problems in a NumPy-like way.
+Vector is a Python 3.8+ library (Python 3.6 and 3.7 supported till `v0.9.0` and `v1.0.0`, respectively) library for 2D, 3D, and [Lorentz vectors](https://en.wikipedia.org/wiki/Special_relativity#Physics_in_spacetime), especially _arrays of vectors_, to solve common physics problems in a NumPy-like way.
 
 Main features of Vector:
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,14 +1,21 @@
 # Changelog
 
-## Version 1.0
+## Version 1.1
 
-### Unreleased
+### Version 1.1.0
+
+#### Features
+
+- feat: implement `sum`, `count`, and `count_nonzero` reductions [#347][]
 
 #### Maintenance
 
 - chore: replace custom definition of np.isclose with numba's np.isclose [#348][]
 
-[#348]: https://github.com/scikit-hep/vector/pull/2348
+[#347]: https://github.com/scikit-hep/vector/pull/347
+[#348]: https://github.com/scikit-hep/vector/pull/348
+
+## Version 1.0
 
 ### Version 1.0.0
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,8 +10,12 @@
 
 #### Maintenance
 
+- chore: remove Python `3.7` support [#355][]
+- chore: use trusted publisher deployment [#354][]
 - chore: replace custom definition of np.isclose with numba's np.isclose [#348][]
 
+[#355]: https://github.com/scikit-hep/vector/pull/355
+[#354]: https://github.com/scikit-hep/vector/pull/354
 [#347]: https://github.com/scikit-hep/vector/pull/347
 [#348]: https://github.com/scikit-hep/vector/pull/348
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,7 +12,7 @@
 Overview
 --------
 
-Vector is a Python 3.7+ library for 2D, 3D, and `Lorentz vectors <https://en.wikipedia.org/wiki/Special_relativity#Physics_in_spacetime>`_, especially *arrays of vectors*, to solve common physics problems in a NumPy-like way.
+Vector is a Python 3.8+ library (Python 3.6 and 3.7 supported till `v0.9.0` and `v1.0.0`, respectively) for 2D, 3D, and `Lorentz vectors <https://en.wikipedia.org/wiki/Special_relativity#Physics_in_spacetime>`_, especially *arrays of vectors*, to solve common physics problems in a NumPy-like way.
 
 Main features of Vector:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,7 +12,7 @@
 Overview
 --------
 
-Vector is a Python 3.8+ library (Python 3.6 and 3.7 supported till `v0.9.0` and `v1.0.0`, respectively) for 2D, 3D, and `Lorentz vectors <https://en.wikipedia.org/wiki/Special_relativity#Physics_in_spacetime>`_, especially *arrays of vectors*, to solve common physics problems in a NumPy-like way.
+Vector is a Python 3.8+ library (Python 3.6 and 3.7 supported till ``v0.9.0`` and ``v1.0.0``, respectively) for 2D, 3D, and `Lorentz vectors <https://en.wikipedia.org/wiki/Special_relativity#Physics_in_spacetime>`_, especially *arrays of vectors*, to solve common physics problems in a NumPy-like way.
 
 Main features of Vector:
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import nox
 
-ALL_PYTHONS = ["3.7", "3.8", "3.9", "3.10", "3.11"]
+ALL_PYTHONS = ["3.8", "3.9", "3.10", "3.11"]
 
 nox.options.sessions = ["lint", "tests", "doctests"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -214,7 +214,7 @@ extend-ignore = [
   "PLR",   # Design related pylint codes
   "E501",  # Line too long
 ]
-target-version = "py37"
+target-version = "py38"
 typing-modules = ["vector._typeutils"]
 src = ["src"]
 unfixable = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ keywords = [
 license = "BSD-3-Clause"
 maintainers = [ {name = "The Scikit-HEP admins", email = "scikit-hep-admins@googlegroups.com"} ]
 authors = [ {name = "Jim Pivarski, Henry Schreiner, Eduardo Rodrigues", email = "eduardo.rodrigues@cern.ch"} ]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
@@ -24,7 +24,6 @@ classifiers = [
   "Operating System :: OS Independent",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
@@ -39,10 +38,8 @@ dynamic = [
   "version",
 ]
 dependencies = [
-  'importlib-metadata>=0.22; python_version < "3.8"',
   "numpy>=1.13.3",
   "packaging>=19",
-  'typing-extensions; python_version < "3.8"',
 ]
 [project.optional-dependencies]
 awkward = [
@@ -50,7 +47,7 @@ awkward = [
 ]
 dev = [
   "awkward>=1.2",
-  'numba>=0.57; python_version >= "3.8"',
+  "numba>=0.57",
   "papermill>=2.4",
   "pytest>=6",
   "pytest-cov>=3",
@@ -138,7 +135,7 @@ disallow_untyped_defs = false
 disallow_untyped_calls = false
 
 [tool.pylint]
-master.py-version = "3.7"
+master.py-version = "3.8"
 reports.output-format = "colorized"
 similarities.ignore-imports = "yes"
 master.jobs = "0"

--- a/src/vector/__init__.py
+++ b/src/vector/__init__.py
@@ -57,14 +57,11 @@ from vector.backends.object import (
 )
 from vector.version import version as __version__
 
-if sys.version_info < (3, 8):
-    import importlib_metadata
-else:
-    import importlib.metadata as importlib_metadata
+from importlib.metadata import version, PackageNotFoundError
 
 
 def _import_awkward() -> None:
-    awk_version = packaging.version.Version(importlib_metadata.version("awkward"))
+    awk_version = packaging.version.Version(version("awkward"))
     if awk_version < packaging.version.Version("1.2.0rc5"):
         # the only context users will see this message is if they're trying to use vector.awk
         # VectorAwkward is still set to None
@@ -75,9 +72,9 @@ def _import_awkward() -> None:
 _is_awkward_v2: bool | None
 try:
     _is_awkward_v2 = packaging.version.Version(
-        importlib_metadata.version("awkward")
+        version("awkward")
     ) >= packaging.version.Version("2.0.0rc1")
-except importlib_metadata.PackageNotFoundError:
+except PackageNotFoundError:
     _is_awkward_v2 = None
 try:
     import awkward

--- a/src/vector/__init__.py
+++ b/src/vector/__init__.py
@@ -57,11 +57,11 @@ from vector.backends.object import (
 )
 from vector.version import version as __version__
 
-from importlib.metadata import version, PackageNotFoundError
+import importlib.metadata
 
 
 def _import_awkward() -> None:
-    awk_version = packaging.version.Version(version("awkward"))
+    awk_version = packaging.version.Version(importlib.metadata.version("awkward"))
     if awk_version < packaging.version.Version("1.2.0rc5"):
         # the only context users will see this message is if they're trying to use vector.awk
         # VectorAwkward is still set to None
@@ -72,9 +72,9 @@ def _import_awkward() -> None:
 _is_awkward_v2: bool | None
 try:
     _is_awkward_v2 = packaging.version.Version(
-        version("awkward")
+        importlib.metadata.version("awkward")
     ) >= packaging.version.Version("2.0.0rc1")
-except PackageNotFoundError:
+except importlib.metadata.PackageNotFoundError:
     _is_awkward_v2 = None
 try:
     import awkward

--- a/src/vector/_typeutils.py
+++ b/src/vector/_typeutils.py
@@ -8,10 +8,7 @@ from __future__ import annotations
 import sys
 import typing
 
-if sys.version_info < (3, 8):
-    from typing_extensions import Protocol, TypedDict
-else:
-    from typing import Protocol, TypedDict
+from typing import Protocol, TypedDict
 
 
 __all__ = [

--- a/tests/backends/test_awkward.py
+++ b/tests/backends/test_awkward.py
@@ -12,7 +12,7 @@ import pytest
 
 import vector
 
-from importlib.metadata import version
+import importlib.metadata
 
 ak = pytest.importorskip("awkward")
 
@@ -21,7 +21,7 @@ pytestmark = pytest.mark.awkward
 
 # Record reducers were added before awkward==2.2.3, but had some bugs.
 awkward_without_record_reducers = packaging.version.Version(
-    version("awkward")
+    importlib.metadata.version("awkward")
 ) < packaging.version.Version("2.2.3")
 
 

--- a/tests/backends/test_awkward.py
+++ b/tests/backends/test_awkward.py
@@ -12,10 +12,7 @@ import pytest
 
 import vector
 
-if sys.version_info < (3, 8):
-    import importlib_metadata
-else:
-    import importlib.metadata as importlib_metadata
+from importlib.metadata import version
 
 ak = pytest.importorskip("awkward")
 
@@ -24,7 +21,7 @@ pytestmark = pytest.mark.awkward
 
 # Record reducers were added before awkward==2.2.3, but had some bugs.
 awkward_without_record_reducers = packaging.version.Version(
-    importlib_metadata.version("awkward")
+    version("awkward")
 ) < packaging.version.Version("2.2.3")
 
 


### PR DESCRIPTION
Following https://github.com/scikit-hep/vector/pull/348#issuecomment-1557596467, this PR removes the support of Python 3.7 from vector. I'm still not completely sure if there was a concensus regarding this but I'll be happy to close this PR if we do want to support Python 3.7.

## Description

**Kindly take a look at [CONTRIBUTING.md](https://github.com/scikit-hep/vector/blob/main/.github/CONTRIBUTING.md).**

_Please describe the purpose of this pull request. Reference and link to any relevant issues or pull requests._

## Checklist

- [ ] Have you followed the guidelines in our Contributing document?
- [ ] Have you checked to ensure there aren't any other open Pull Requests for the required change?
- [ ] Does your submission pass pre-commit? (`$ pre-commit run --all-files` or `$ nox -s lint`)
- [ ] Does your submission pass tests? (`$ pytest` or `$ nox -s tests`)
- [ ] Does the documentation build with your changes? (`$ cd docs; make clean; make html` or `$ nox -s docs`)
- [ ] Does your submission pass the doctests? (`$ xdoctest ./src/vector` or `$ nox -s doctests`)

## Before Merging

- [ ] Summarize the commit messages into a brief review of the Pull request.
