### PR TITLE
chore: target-version no longer needed by Black or Ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,6 @@ extend-ignore = [
   "PLR",   # Design related pylint codes
   "E501",  # Line too long
 ]
-target-version = "py38"
 typing-modules = ["vector._typeutils"]
 src = ["src"]
 unfixable = [


### PR DESCRIPTION
See https://github.com/scientific-python/cookie/issues/201.

Committed via https://github.com/asottile/all-repos