### PR TITLE
chore: remove license string (not standard)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ readme = { file = "README.md", content-type = "text/markdown" }
 keywords = [
   "vector",
 ]
-license = "BSD-3-Clause"
 maintainers = [ {name = "The Scikit-HEP admins", email = "scikit-hep-admins@googlegroups.com"} ]
 authors = [ {name = "Jim Pivarski, Henry Schreiner, Eduardo Rodrigues", email = "eduardo.rodrigues@cern.ch"} ]
 requires-python = ">=3.8"
@@ -159,6 +158,7 @@ enable_error_code = [
   "truthy-bool",
   "redundant-expr",
 ]
+warn_unreachable = false
 
 [[tool.mypy.overrides]]
 module = [


### PR DESCRIPTION
This is not following PEP 621, and we already have the canonical license classifier.
