### PR TITLE
fix: `keepdims` in `numpy.sum` should not be `None`

### DIFF
--- a/src/vector/__init__.py
+++ b/src/vector/__init__.py
@@ -32,7 +32,7 @@ from vector._methods import (
     Vector4D,
     dim,
 )
-from vector._version import version as __version__
+from vector._version import __version__ # type: ignore[import]
 from vector.backends.awkward_constructors import Array, zip
 from vector.backends.awkward_constructors import Array as awk
 from vector.backends.numpy import (

--- a/src/vector/__init__.py
+++ b/src/vector/__init__.py
@@ -32,7 +32,7 @@ from vector._methods import (
     Vector4D,
     dim,
 )
-from vector._version import __version__
+from vector._version import version as __version__
 from vector.backends.awkward_constructors import Array, zip
 from vector.backends.awkward_constructors import Array as awk
 from vector.backends.numpy import (

--- a/src/vector/__init__.py
+++ b/src/vector/__init__.py
@@ -32,7 +32,7 @@ from vector._methods import (
     Vector4D,
     dim,
 )
-from vector._version import __version__  # type: ignore[import]
+from vector._version import __version__
 from vector.backends.awkward_constructors import Array, zip
 from vector.backends.awkward_constructors import Array as awk
 from vector.backends.numpy import (

--- a/src/vector/__init__.py
+++ b/src/vector/__init__.py
@@ -32,7 +32,7 @@ from vector._methods import (
     Vector4D,
     dim,
 )
-from vector._version import __version__ # type: ignore[import]
+from vector._version import __version__  # type: ignore[import]
 from vector.backends.awkward_constructors import Array, zip
 from vector.backends.awkward_constructors import Array as awk
 from vector.backends.numpy import (

--- a/src/vector/backends/numpy.py
+++ b/src/vector/backends/numpy.py
@@ -20,7 +20,6 @@ import collections.abc
 import typing
 
 import numpy
-from numpy._globals import _NoValue, _NoValueType
 
 import vector.backends.object
 from vector._methods import (
@@ -69,7 +68,7 @@ def _reduce_sum(
     axis: int | None = None,
     dtype: typing.Any = None,
     out: typing.Any = None,
-    keepdims: bool | _NoValueType = _NoValue,
+    keepdims: bool = False,
     initial: typing.Any = None,
     where: typing.Any = None,
 ) -> T:
@@ -754,7 +753,7 @@ class VectorNumpy(Vector, GetItem):
         axis: int | None = None,
         dtype: numpy.dtype[typing.Any] | str | None = None,
         out: ArrayLike | None = None,
-        keepdims: bool | _NoValueType = _NoValue,
+        keepdims: bool = False,
         initial: typing.Any = None,
         where: typing.Any = None,
     ) -> SameVectorNumpyType:

--- a/src/vector/backends/numpy.py
+++ b/src/vector/backends/numpy.py
@@ -20,6 +20,7 @@ import collections.abc
 import typing
 
 import numpy
+from numpy._globals import _NoValue, _NoValueType
 
 import vector.backends.object
 from vector._methods import (
@@ -68,7 +69,7 @@ def _reduce_sum(
     axis: int | None = None,
     dtype: typing.Any = None,
     out: typing.Any = None,
-    keepdims: bool | None = None,
+    keepdims: bool | _NoValueType = _NoValue,
     initial: typing.Any = None,
     where: typing.Any = None,
 ) -> T:
@@ -753,7 +754,7 @@ class VectorNumpy(Vector, GetItem):
         axis: int | None = None,
         dtype: numpy.dtype[typing.Any] | str | None = None,
         out: ArrayLike | None = None,
-        keepdims: bool | None = None,
+        keepdims: bool | _NoValueType = _NoValue,
         initial: typing.Any = None,
         where: typing.Any = None,
     ) -> SameVectorNumpyType:

--- a/tests/backends/test_numpy.py
+++ b/tests/backends/test_numpy.py
@@ -247,7 +247,7 @@ def test_sum_2d():
         [[(1, 0.1), (4, 0.2), (0, 0)], [(1, 0.3), (4, 0.4), (1, 0.1)]],
         dtype=[("rho", numpy.float64), ("phi", numpy.float64)],
     )
-    assert numpy.sum(v, axis=0, keepdims=True).allclose(
+    assert numpy.sum(v, axis=0, keepdims=False).allclose(
         vector.VectorNumpy2D(
             [
                 [
@@ -269,6 +269,20 @@ def test_sum_2d():
             dtype=[("x", numpy.float64), ("y", numpy.float64)],
         )
     )
+    assert numpy.sum(v, axis=0).allclose(
+        vector.VectorNumpy2D(
+            [
+                (1.950340654403632, 0.3953536233081677),
+                (7.604510287376507, 2.3523506924148467),
+                (0.9950041652780258, 0.09983341664682815),
+            ],
+            dtype=[("x", numpy.float64), ("y", numpy.float64)],
+        )
+    )
+    assert numpy.sum(v, axis=0, keepdims=False).shape == (3,)
+    assert numpy.sum(v, axis=0, keepdims=True).shape == (1, 3)
+    assert numpy.sum(v, axis=0).shape == (3,)
+
     assert numpy.sum(v, axis=1, keepdims=True).allclose(
         vector.VectorNumpy2D(
             [[(4.91527048, 0.89451074)], [(5.63458463, 1.95302699)]],
@@ -281,6 +295,15 @@ def test_sum_2d():
             dtype=[("x", numpy.float64), ("y", numpy.float64)],
         )
     )
+    assert numpy.sum(v, axis=1).allclose(
+        vector.VectorNumpy2D(
+            [(4.91527048, 0.89451074), (5.63458463, 1.95302699)],
+            dtype=[("x", numpy.float64), ("y", numpy.float64)],
+        )
+    )
+    assert numpy.sum(v, axis=1, keepdims=False).shape == (2,)
+    assert numpy.sum(v, axis=1, keepdims=True).shape == (2, 1)
+    assert numpy.sum(v, axis=1).shape == (2,)
 
 
 def test_sum_3d():
@@ -317,6 +340,20 @@ def test_sum_3d():
             dtype=[("x", numpy.float64), ("y", numpy.float64), ("z", numpy.float64)],
         )
     )
+    assert numpy.sum(v, axis=0).allclose(
+        vector.VectorNumpy3D(
+            [
+                (2.0, 4.0, 25.55454594),
+                (8.0, 10.0, 33.36521103),
+                (1.0, 1.0, -0.48314535),
+            ],
+            dtype=[("x", numpy.float64), ("y", numpy.float64), ("z", numpy.float64)],
+        )
+    )
+    assert numpy.sum(v, axis=0, keepdims=False).shape == (3,)
+    assert numpy.sum(v, axis=0, keepdims=True).shape == (1, 3)
+    assert numpy.sum(v, axis=0).shape == (3,)
+
     assert numpy.sum(v, axis=1, keepdims=True).allclose(
         vector.VectorNumpy3D(
             [[(5.0, 7.0, 53.87369799)], [(6.0, 8.0, 4.56291362)]],
@@ -329,6 +366,15 @@ def test_sum_3d():
             dtype=[("x", numpy.float64), ("y", numpy.float64), ("z", numpy.float64)],
         )
     )
+    assert numpy.sum(v, axis=1).allclose(
+        vector.VectorNumpy3D(
+            [(5.0, 7.0, 53.87369799), (6.0, 8.0, 4.56291362)],
+            dtype=[("x", numpy.float64), ("y", numpy.float64), ("z", numpy.float64)],
+        )
+    )
+    assert numpy.sum(v, axis=1, keepdims=False).shape == (2,)
+    assert numpy.sum(v, axis=1, keepdims=True).shape == (2, 1)
+    assert numpy.sum(v, axis=1).shape == (2,)
 
 
 def test_sum_4d():
@@ -352,6 +398,15 @@ def test_sum_4d():
         (8, 10, 12, 2),
         (1, 1, 1, 3),
     ]
+    assert numpy.sum(v, axis=0).tolist() == [
+        (2, 4, 6, 12),
+        (8, 10, 12, 2),
+        (1, 1, 1, 3),
+    ]
+    assert numpy.sum(v, axis=0, keepdims=False).shape == (3,)
+    assert numpy.sum(v, axis=0, keepdims=True).shape == (1, 3)
+    assert numpy.sum(v, axis=0).shape == (3,)
+
     assert numpy.sum(v, axis=1, keepdims=True).tolist() == [
         [(5, 7, 9, 9)],
         [(6, 8, 10, 8)],
@@ -360,6 +415,13 @@ def test_sum_4d():
         (5, 7, 9, 9),
         (6, 8, 10, 8),
     ]
+    assert numpy.sum(v, axis=1).tolist() == [
+        (5, 7, 9, 9),
+        (6, 8, 10, 8),
+    ]
+    assert numpy.sum(v, axis=1, keepdims=False).shape == (2,)
+    assert numpy.sum(v, axis=1, keepdims=True).shape == (2, 1)
+    assert numpy.sum(v, axis=1).shape == (2,)
 
 
 def test_count_nonzero_2d():


### PR DESCRIPTION
## Description

Fixes #372

See https://github.com/scikit-hep/vector/issues/372#issuecomment-1708622415

I've added tests for the default case as well.

## Checklist

- [X] Have you followed the guidelines in our Contributing document?
- [X] Have you checked to ensure there aren't any other open Pull Requests for the required change?
- [X] Does your submission pass pre-commit? (`$ pre-commit run --all-files` or `$ nox -s lint`)
- [X] Does your submission pass tests? (`$ pytest` or `$ nox -s tests`)
- [X] Does the documentation build with your changes? (`$ cd docs; make clean; make html` or `$ nox -s docs`)
- [X] Does your submission pass the doctests? (`$ xdoctest ./src/vector` or `$ nox -s doctests`)

## Before Merging

- [ ] Summarize the commit messages into a brief review of the Pull request.
