### PR TITLE
FIX: got rid of type: ignore[unreachable] comments #221

### DIFF
--- a/src/vector/backends/awkward.py
+++ b/src/vector/backends/awkward.py
@@ -584,7 +584,10 @@ class TemporalAwkwardTau(TemporalAwkward, TemporalTau):
         return (self.tau,)
 
 
-def _class_to_name(cls: type[VectorProtocol]) -> str:
+T = typing.TypeVar("T", bound=VectorProtocol)
+
+
+def _class_to_name(cls: type[T]) -> str:
     # respect the type of classes inheriting VectorAwkward classes
     is_vector = "vector.backends" in cls.__module__
     if issubclass(cls, Momentum):


### PR DESCRIPTION
## Description

Fixes #221 
To fix this, we can use a TypeVar to bound the input cls to VectorProtocol. This avoids the inconsistent inheritance issue.
We also don't need the unreachable ignores anymore since the code now typechecks correctly.

## Checklist

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't any other open Pull Requests for the required change?
- [x] Does your submission pass pre-commit? (`$ pre-commit run --all-files` or `$ nox -s lint`)
- [ ] Does your submission pass tests? (`$ pytest` or `$ nox -s tests`)
- [ ] Does the documentation build with your changes? (`$ cd docs; make clean; make html` or `$ nox -s docs`)
- [x] Does your submission pass the doctests? (`$ xdoctest ./src/vector` or `$ nox -s doctests`)

## Before Merging

- [x] Summarize the commit messages into a brief review of the Pull request.
