### PR TITLE
fix: call the square implementation for power 2 on object vectors

### DIFF
--- a/src/vector/backends/object.py
+++ b/src/vector/backends/object.py
@@ -387,7 +387,7 @@ class VectorObject(Vector):
         return _replace_data(self, numpy.true_divide(self, other))  # type: ignore[call-overload]
 
     def __pow__(self, other: float) -> float:
-        return numpy.power(self, other)  # type: ignore[call-overload]
+        return numpy.square(self) if other == 2 else numpy.power(self, other)  # type: ignore[call-overload]
 
     def __matmul__(self, other: VectorProtocol) -> float:
         return numpy.matmul(self, other)  # type: ignore[call-overload]

--- a/tests/compute/test_isclose.py
+++ b/tests/compute/test_isclose.py
@@ -62,8 +62,6 @@ def test_spatial_object():
 
     for t1 in "xyz", "xytheta", "xyeta", "rhophiz", "rhophitheta", "rhophieta":
         for t2 in "xyz", "xytheta", "xyeta", "rhophiz", "rhophitheta", "rhophieta":
-            print(t1, t2)
-
             transformed1, transformed2 = (
                 getattr(v1, "to_" + t1)(),
                 getattr(v2, "to_" + t2)(),

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import os
 import pickle
 
+import numpy as np
 import pytest
 
 import vector
@@ -47,3 +48,16 @@ def test_issue_161():
     with open(file_path, "rb") as f:
         a = ak.from_buffers(*pickle.load(f))
     repro(generator_like_jet_constituents=a.constituents)
+
+
+def test_issue_443():
+    ak = pytest.importorskip("awkward")
+    vector.register_awkward()
+
+    assert vector.array({"E": [1], "px": [1], "py": [1], "pz": [1]}) ** 2 == np.array(
+        [-2.0]
+    )
+    assert ak.zip(
+        {"E": [1], "px": [1], "py": [1], "pz": [1]}, with_name="Momentum4D"
+    ) ** 2 == ak.Array([-2])
+    assert vector.obj(E=1, px=1, py=1, pz=1) ** 2 == -2


### PR DESCRIPTION
## Description

Fixes #443

**Kindly take a look at [CONTRIBUTING.md](https://github.com/scikit-hep/vector/blob/main/.github/CONTRIBUTING.md).**

_Please describe the purpose of this pull request. Reference and link to any relevant issues or pull requests._

## Checklist

- [ ] Have you followed the guidelines in our Contributing document?
- [ ] Have you checked to ensure there aren't any other open Pull Requests for the required change?
- [ ] Does your submission pass pre-commit? (`$ pre-commit run --all-files` or `$ nox -s lint`)
- [ ] Does your submission pass tests? (`$ pytest` or `$ nox -s tests`)
- [ ] Does the documentation build with your changes? (`$ cd docs; make clean; make html` or `$ nox -s docs`)
- [ ] Does your submission pass the doctests? (`$ pytest --doctest-plus src/vector/` or `$ nox -s doctests`)

## Before Merging

- [ ] Summarize the commit messages into a brief review of the Pull request.
