### PR TITLE
fix: use negfactor in negfactor scale test

### DIFF
--- a/tests/compute/test_scale.py
+++ b/tests/compute/test_scale.py
@@ -271,14 +271,14 @@ def test_lorentz_negtime_negfactor():
         "rhophietat",
     ):
         tvec = getattr(vec, "to_" + t1)()
-        out = tvec.scale(1.75)
+        out = tvec.scale(-1.75)
         assert type(out.azimuthal) == type(tvec.azimuthal)  # noqa: E721
         assert type(out.longitudinal) == type(tvec.longitudinal)  # noqa: E721
         assert type(out.temporal) == type(tvec.temporal)  # noqa: E721
-        assert out.x == pytest.approx(1 * 1.75)
-        assert out.y == pytest.approx(2 * 1.75)
-        assert out.z == pytest.approx(3 * 1.75)
-        assert out.t == pytest.approx(-1.5 * 1.75)
+        assert out.x == pytest.approx(1 * -1.75)
+        assert out.y == pytest.approx(2 * -1.75)
+        assert out.z == pytest.approx(3 * -1.75)
+        assert out.t == pytest.approx(-1.5 * -1.75)
 
     for t1 in (
         "xyztau",


### PR DESCRIPTION
## Description

**Kindly take a look at [CONTRIBUTING.md](https://github.com/scikit-hep/vector/blob/main/.github/CONTRIBUTING.md).**

_Please describe the purpose of this pull request. Reference and link to any relevant issues or pull requests._

## Checklist

- [ ] Have you followed the guidelines in our Contributing document?
- [ ] Have you checked to ensure there aren't any other open Pull Requests for the required change?
- [ ] Does your submission pass pre-commit? (`$ pre-commit run --all-files` or `$ nox -s lint`)
- [ ] Does your submission pass tests? (`$ pytest` or `$ nox -s tests`)
- [ ] Does the documentation build with your changes? (`$ cd docs; make clean; make html` or `$ nox -s docs`)
- [ ] Does your submission pass the doctests? (`$ pytest --doctest-plus src/vector/` or `$ nox -s doctests`)

## Before Merging

- [ ] Summarize the commit messages into a brief review of the Pull request.
