### PR TITLE
ci: Add GitHub artifact attestations to package distribution

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -9,6 +9,10 @@ on:
 jobs:
   dist:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      attestations: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:
@@ -17,12 +21,17 @@ jobs:
       - name: Build SDist and wheel
         run: pipx run build
 
+      - name: Check metadata
+        run: pipx run twine check dist/*
+
+      - name: Generate artifact attestation for sdist and wheel
+        uses: actions/attest-build-provenance@173725a1209d09b31f9d30a3890cf2757ebbff0d # v1.1.2
+        with:
+          subject-path: "dist/vector-*"
+
       - uses: actions/upload-artifact@v4
         with:
           path: dist/*
-
-      - name: Check metadata
-        run: pipx run twine check dist/*
 
   publish:
     needs: [dist]
@@ -39,5 +48,18 @@ jobs:
         with:
           name: artifact
           path: dist
+
+      - name: List distributions to be deployed
+        run: ls -l dist/
+
+      - name: Verify sdist artifact attestation
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh attestation verify dist/vector-*.tar.gz --repo ${{ github.repository }}
+
+      - name: Verify wheel artifact attestation
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh attestation verify dist/vector-*.whl --repo ${{ github.repository }}
 
       - uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Description

* Add generation of GitHub artifact attestations to built sdist and wheel before upload. c.f.:
   - https://github.blog/2024-05-02-introducing-artifact-attestations-now-in-public-beta/
   - https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds
* Add verification of artifact attestation before publishing vector to PyPI using the 'gh attestation verify' CLI API, added in v2.49.0.
   - c.f. https://github.com/cli/cli/releases/tag/v2.49.0

## Checklist

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't any other open Pull Requests for the required change?
- [x] Does your submission pass pre-commit? (`$ pre-commit run --all-files` or `$ nox -s lint`)
- [x] Does your submission pass tests? (`$ pytest` or `$ nox -s tests`)
- [x] Does the documentation build with your changes? (`$ cd docs; make clean; make html` or `$ nox -s docs`)
- [x] Does your submission pass the doctests? (`$ pytest --doctest-plus src/vector/` or `$ nox -s doctests`)

## Before Merging

- [x] Summarize the commit messages into a brief review of the Pull request.

```
* Add generation of GitHub artifact attestations to built sdist and wheel
  before upload.
  c.f.:
   - https://github.blog/2024-05-02-introducing-artifact-attestations-now-in-public-beta/
   - https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds
* Add verification of artifact attestation before publishing vector to PyPI
  using the 'gh attestation verify' CLI API, added in v2.49.0.
   - c.f. https://github.com/cli/cli/releases/tag/v2.49.0
```