### PR TITLE
Added examples for azimuthal and longitudinal properties in 3D and 4D

### DIFF
--- a/src/vector/backends/numpy.py
+++ b/src/vector/backends/numpy.py
@@ -1424,14 +1424,44 @@ class VectorNumpy3D(VectorNumpy, Spatial, Vector3D, FloatArray):  # type: ignore
 
     @property
     def azimuthal(self) -> AzimuthalNumpy:
-        """Returns the azimuthal type class for the given ``VectorNumpy3D`` object."""
-        # TODO: Add an example here - see https://github.com/scikit-hep/vector/issues/194
+        """
+        Returns the azimuthal type class for the given ``VectorNumpy3D`` object.
+
+        Example:
+            >>> import vector
+            >>> vec = vector.array(
+            ... [
+            ...     (1.1, 2.1, 3.1),
+            ...     (1.2, 2.2, 3.2),
+            ...     (1.3, 2.3, 3.3),
+            ...     (1.4, 2.4, 4.4),
+            ...     (1.5, 2.5, 5.5)
+            ...    ], dtype=[("x", float), ("y", float), ("z", float)]
+            ... )
+            >>> print(vec.azimuthal)
+            [(1.1, 2.1) (1.2, 2.2) (1.3, 2.3) (1.4, 2.4) (1.5, 2.5)]
+        """
         return self.view(self._azimuthal_type)
 
     @property
     def longitudinal(self) -> LongitudinalNumpy:
-        """Returns the longitudinal type class for the given ``VectorNumpy3D`` object."""
-        # TODO: Add an example here - see https://github.com/scikit-hep/vector/issues/194
+        """
+        Returns the longitudinal type class for the given ``VectorNumpy3D`` object.
+
+        Example:
+            >>> import vector
+            >>> vec = vector.array(
+            ... [
+            ...     (1.1, 2.1, 3.1),
+            ...     (1.2, 2.2, 3.2),
+            ...     (1.3, 2.3, 3.3),
+            ...     (1.4, 2.4, 4.4),
+            ...     (1.5, 2.5, 5.5)
+            ...    ], dtype=[("x", float), ("y", float), ("z", float)]
+            ... )
+            >>> print(vec.longitudinal)
+            [(3.1,) (3.2,) (3.3,) (4.4,) (5.5,)]
+        """
         return self.view(self._longitudinal_type)
 
     def _wrap_result(
@@ -1704,14 +1734,46 @@ class VectorNumpy4D(VectorNumpy, Lorentz, Vector4D, FloatArray):  # type: ignore
 
     @property
     def azimuthal(self) -> AzimuthalNumpy:
-        """Returns the azimuthal type class for the given ``VectorNumpy4D`` object."""
-        # TODO: Add an example here - see https://github.com/scikit-hep/vector/issues/194
+        """
+        Returns the azimuthal type class for the given ``VectorNumpy4D`` object.
+
+        Example:
+            >>> import vector
+            >>> # Create a 4D vector array with (x, y, z, t) components
+            >>> vec_4d = vector.array(
+            ... [
+            ...     (1.1, 2.1, 3.1, 4.1),
+            ...     (1.2, 2.2, 3.2, 4.2),
+            ...     (1.3, 2.3, 3.3, 4.3),
+            ...     (1.4, 2.4, 3.4, 4.4),
+            ...     (1.5, 2.5, 3.5, 4.5)
+            ... ], dtype=[("x", float), ("y", float), ("z", float), ("t", float)]
+            ... )
+            >>> print(vec_4d.azimuthal)
+            [(1.1, 2.1) (1.2, 2.2) (1.3, 2.3) (1.4, 2.4) (1.5, 2.5)]
+        """
         return self.view(self._azimuthal_type)
 
     @property
     def longitudinal(self) -> LongitudinalNumpy:
-        """Returns the longitudinal type class for the given ``Vectornumpy4D`` object."""
-        # TODO: Add an example here - see https://github.com/scikit-hep/vector/issues/194
+        """
+        Returns the longitudinal type class for the given ``Vectornumpy4D`` object.
+
+        Example:
+            >>> import vector
+            >>> # Create a 4D vector array with (x, y, z, t) components
+            >>> vec_4d = vector.array(
+            ... [
+            ...     (1.1, 2.1, 3.1, 4.1),
+            ...     (1.2, 2.2, 3.2, 4.2),
+            ...     (1.3, 2.3, 3.3, 4.3),
+            ...     (1.4, 2.4, 3.4, 4.4),
+            ...     (1.5, 2.5, 3.5, 4.5)
+            ... ], dtype=[("x", float), ("y", float), ("z", float), ("t", float)]
+            ... )
+            >>> print(vec_4d.longitudinal)
+            [(3.1,) (3.2,) (3.3,) (3.4,) (3.5,)]
+        """
         return self.view(self._longitudinal_type)
 
     @property

--- a/src/vector/backends/numpy.py
+++ b/src/vector/backends/numpy.py
@@ -1741,7 +1741,7 @@ class VectorNumpy4D(VectorNumpy, Lorentz, Vector4D, FloatArray):  # type: ignore
 
         Example:
             >>> import vector
-            >>> vec_4d = vector.array(
+            >>> vec = vector.array(
             ... [
             ...     (1.1, 2.1, 3.1, 4.1),
             ...     (1.2, 2.2, 3.2, 4.2),
@@ -1750,7 +1750,7 @@ class VectorNumpy4D(VectorNumpy, Lorentz, Vector4D, FloatArray):  # type: ignore
             ...     (1.5, 2.5, 3.5, 4.5)
             ... ], dtype=[("x", float), ("y", float), ("z", float), ("t", float)]
             ... )
-            >>> vec_4d.azimuthal
+            >>> vec.azimuthal
             AzimuthalNumpyXY([(1.1, 2.1), (1.2, 2.2), (1.3, 2.3), (1.4, 2.4),
                   (1.5, 2.5)], dtype=[('x', '<f8'), ('y', '<f8')])
         """
@@ -1763,7 +1763,7 @@ class VectorNumpy4D(VectorNumpy, Lorentz, Vector4D, FloatArray):  # type: ignore
 
         Example:
             >>> import vector
-            >>> vec_4d = vector.array(
+            >>> vec = vector.array(
             ... [
             ...     (1.1, 2.1, 3.1, 4.1),
             ...     (1.2, 2.2, 3.2, 4.2),
@@ -1772,7 +1772,7 @@ class VectorNumpy4D(VectorNumpy, Lorentz, Vector4D, FloatArray):  # type: ignore
             ...     (1.5, 2.5, 3.5, 4.5)
             ... ], dtype=[("x", float), ("y", float), ("z", float), ("t", float)]
             ... )
-            >>> vec_4d.longitudinal
+            >>> vec.longitudinal
             LongitudinalNumpyZ([(3.1,), (3.2,), (3.3,), (3.4,), (3.5,)],
                    dtype=[('z', '<f8')])
         """

--- a/src/vector/backends/numpy.py
+++ b/src/vector/backends/numpy.py
@@ -1438,8 +1438,9 @@ class VectorNumpy3D(VectorNumpy, Spatial, Vector3D, FloatArray):  # type: ignore
             ...     (1.5, 2.5, 5.5)
             ...    ], dtype=[("x", float), ("y", float), ("z", float)]
             ... )
-            >>> print(vec.azimuthal)
-            [(1.1, 2.1) (1.2, 2.2) (1.3, 2.3) (1.4, 2.4) (1.5, 2.5)]
+            >>> vec.azimuthal
+            AzimuthalNumpyXY([(1.1, 2.1), (1.2, 2.2), (1.3, 2.3), (1.4, 2.4),
+                  (1.5, 2.5)], dtype=[('x', '<f8'), ('y', '<f8')])
         """
         return self.view(self._azimuthal_type)
 
@@ -1459,8 +1460,9 @@ class VectorNumpy3D(VectorNumpy, Spatial, Vector3D, FloatArray):  # type: ignore
             ...     (1.5, 2.5, 5.5)
             ...    ], dtype=[("x", float), ("y", float), ("z", float)]
             ... )
-            >>> print(vec.longitudinal)
-            [(3.1,) (3.2,) (3.3,) (4.4,) (5.5,)]
+            >>> vec.longitudinal
+            LongitudinalNumpyZ([(3.1,), (3.2,), (3.3,), (4.4,), (5.5,)],
+                   dtype=[('z', '<f8')])
         """
         return self.view(self._longitudinal_type)
 
@@ -1739,7 +1741,6 @@ class VectorNumpy4D(VectorNumpy, Lorentz, Vector4D, FloatArray):  # type: ignore
 
         Example:
             >>> import vector
-            >>> # Create a 4D vector array with (x, y, z, t) components
             >>> vec_4d = vector.array(
             ... [
             ...     (1.1, 2.1, 3.1, 4.1),
@@ -1749,19 +1750,19 @@ class VectorNumpy4D(VectorNumpy, Lorentz, Vector4D, FloatArray):  # type: ignore
             ...     (1.5, 2.5, 3.5, 4.5)
             ... ], dtype=[("x", float), ("y", float), ("z", float), ("t", float)]
             ... )
-            >>> print(vec_4d.azimuthal)
-            [(1.1, 2.1) (1.2, 2.2) (1.3, 2.3) (1.4, 2.4) (1.5, 2.5)]
+            >>> vec_4d.azimuthal
+            AzimuthalNumpyXY([(1.1, 2.1), (1.2, 2.2), (1.3, 2.3), (1.4, 2.4),
+                  (1.5, 2.5)], dtype=[('x', '<f8'), ('y', '<f8')])
         """
         return self.view(self._azimuthal_type)
 
     @property
     def longitudinal(self) -> LongitudinalNumpy:
         """
-        Returns the longitudinal type class for the given ``Vectornumpy4D`` object.
+        Returns the longitudinal type class for the given ``VectorNumpy4D`` object.
 
         Example:
             >>> import vector
-            >>> # Create a 4D vector array with (x, y, z, t) components
             >>> vec_4d = vector.array(
             ... [
             ...     (1.1, 2.1, 3.1, 4.1),
@@ -1771,8 +1772,9 @@ class VectorNumpy4D(VectorNumpy, Lorentz, Vector4D, FloatArray):  # type: ignore
             ...     (1.5, 2.5, 3.5, 4.5)
             ... ], dtype=[("x", float), ("y", float), ("z", float), ("t", float)]
             ... )
-            >>> print(vec_4d.longitudinal)
-            [(3.1,) (3.2,) (3.3,) (3.4,) (3.5,)]
+            >>> vec_4d.longitudinal
+            LongitudinalNumpyZ([(3.1,), (3.2,), (3.3,), (3.4,), (3.5,)],
+                   dtype=[('z', '<f8')])
         """
         return self.view(self._longitudinal_type)
 


### PR DESCRIPTION
## Description

This PR adds descriptive example to the following properties in /src/vector/backends/numpy.py (Mentioned in #503)

- Azimuthal - 3D
- Azimuthal - 4D
- Longitudinal - 3D
- Longitudinal - 4D

The demo examples have been run and verified.

## Checklist

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't any other open Pull Requests for the required change?
- [x] Does your submission pass pre-commit? (`$ pre-commit run --all-files` or `$ nox -s lint`)
- [x] Does your submission pass tests? (`$ pytest` or `$ nox -s tests`)
- [x] Does the documentation build with your changes? (`$ cd docs; make clean; make html` or `$ nox -s docs`)
- [x] Does your submission pass the doctests? (`$ pytest --doctest-plus src/vector/` or `$ nox -s doctests`)

## Before Merging

- [x] Summarize the commit messages into a brief review of the Pull request.
