### PR TITLE
feat: add a PyTorch backend

### DIFF
--- a/src/vector/backends/torch.py
+++ b/src/vector/backends/torch.py
@@ -1,0 +1,120 @@
+# Copyright (c) 2019-2024, Jonas Eschle, Jim Pivarski, Eduardo Rodrigues, and Henry Schreiner.
+#
+# Distributed under the 3-clause BSD license, see accompanying file LICENSE
+# or https://github.com/scikit-hep/vector for details.
+
+"""
+Defines behaviors for PyTorch Tensor. New tensors created with the
+
+.. code-block:: python
+
+    vector.tensor(...)
+
+function will have these behaviors built in (and will pass them to any derived
+tensors).
+"""
+
+from __future__ import annotations
+
+from packaging.version import parse as parse_version
+
+import torch
+
+if parse_version(torch.__version__) < parse_version("1.7.0"):
+    # https://pytorch.org/docs/stable/notes/extending.html#subclassing-torch-tensor
+    raise ImportError("Vector's PyTorch backend requires PyTorch >= 1.7.0")
+
+
+class Index:
+    pass
+
+
+class AzimuthalIndex(Index):
+    pass
+
+
+class AzimuthalXYIndex(AzimuthalIndex):
+    def __init__(self, x, y):
+        self._x = x
+        self._y = y
+
+    @property
+    def x(self):
+        return self._x
+
+    @property
+    def y(self):
+        return self._y
+
+    def _constructors(self):
+        return f"x_index={self._x}, y_index={self._y}"
+
+
+class VectorTensor(torch.Tensor):
+    def __repr__(self):
+        step1 = torch.Tensor.__repr__(self)
+
+        pos_paren1 = step1.index("(")
+        prefix = "vector.tensor"
+        ws_before = "\n" + (" " * pos_paren1)
+        ws_after = "\n" + (" " * len(prefix))
+        step2 = prefix + step1[pos_paren1:].replace(ws_before, ws_after)
+
+        pos_paren2 = step2.rindex(")")
+        eoln = "\n    " if "\n" in step2 else " "
+        step3 = step2[:pos_paren2] + f",{eoln}{self._constructors()})"
+
+        return step3
+
+    @property
+    def raw(self):
+        return torch.Tensor.__new__(torch.Tensor, self)
+
+    @classmethod
+    def __torch_function__(cls, func, types, args=(), kwargs=None):
+        if kwargs is None:
+            kwargs = {}
+
+        # RIGHT HERE, we need to deal with all the types of functions:
+        #   * 1 vector  -> non-vector      e.g. coordinate, abs, deltaphi
+        #   * 1 vector  -> vector          e.g. rotation, scalar multiplication,
+        #                                       coordinate transformation
+        #   * 2 vectors -> non-vector      e.g. is_parallel, equal
+        #   * 2 vectors -> vector          e.g. add, cross-product, boost
+        #   * vectors are untouched        e.g. copy, dtype or device change
+        #
+        # Which functions with more than 1 vector arguments...
+        #   * need to shuffle indexes to put them in the same index positions?
+        #   * ~~need to convert coordinate systems~~ NO: compute funcs do that
+        #   * need to project N-d to n-d?
+        #   * need to complain if vector dimensions are mismatched?
+
+        raw_args = [x.raw if isinstance(x, VectorTensor) else x for x in args]
+
+        out = func(*raw_args, **kwargs)
+
+        if isinstance(out, torch.Tensor):
+            args[0]._apply_one(out)
+
+        return out
+
+
+class Vector2DTensor(VectorTensor):
+    @staticmethod
+    def __new__(cls, data, azimuthal_index, **kwargs):
+        out = torch.Tensor.__new__(torch.Tensor, data, **kwargs)
+        out.__class__ = cls
+        out._azimuthal_index = azimuthal_index
+        return out
+
+    @property
+    def azimuthal_index(self):
+        return self._azimuthal_index
+
+    def _constructors(self):
+        return self._azimuthal_index._constructors()
+
+    def _apply_one(self, out):
+        out.__class__ = type(self)
+        out._azimuthal_index = self._azimuthal_index
+        return out


### PR DESCRIPTION
I've become familiar with PyTorch recently because of writing https://github.com/hsf-training/deep-learning-intro-for-hep/

I've also been looking at the Vector documentation because I think it needs an overhaul to be more physicist-friendly. Along the way, I noticed that there's no PyTorch backend yet, but it would be really useful to have one. Vector's approach to NumPy arrays is to expect them to be [structured arrays](https://numpy.org/doc/2.1/user/basics.rec.html), but feature vectors in an ML model are always unstructured. (Note: there's a conversion function: [np.lib.recfunctions.structured_to_unstructured](https://numpy.org/doc/2.1/user/basics.rec.html#numpy.lib.recfunctions.structured_to_unstructured).)

Generally, feature vectors in an ML model will have a few indexes corresponding to vector coordinates and many others that don't. If the first 4 features are $p_T$, $\eta$, $\phi$, and mass, we might want to denote that with `pt_index=0, phi_index=2, eta_index=1, mass_index=3` in such a way that they can be picked out of a tensor named `features` like

```python
features[..., pt_index]
features[..., phi_index]
features[..., eta_index]
features[..., mass_index]
```

It would be nice if the `features` vector was a subclass of `torch.Tensor` that produces the above via

```python
features.pt
features.phi
features.eta
features.mass
```

And then if someone asks for

```python
features.pz
```

it would compute $p_z$ using the appropriate compute function. With `torch` as the `lib` argument of the `vector._compute` functions, they would all be autodiffed and could be used in an optimization procedure with backpropagation. The library functions that `vector._compute` needs,

https://github.com/scikit-hep/vector/blob/7cd311d917f2793329354e3725a3216f5d01f466/tests/test_compute_features.py#L357-L380

are all defined in the `torch` module:

```python
>>> torch.absolute
<built-in method absolute of type object at 0x7596c071cde0>
>>> torch.sign
<built-in method sign of type object at 0x7596c071cde0>
>>> torch.copysign
<built-in method copysign of type object at 0x7596c071cde0>
>>> torch.maximum
<built-in method maximum of type object at 0x7596c071cde0>
>>> torch.minimum
<built-in method minimum of type object at 0x7596c071cde0>
>>> torch.sqrt
<built-in method sqrt of type object at 0x7596c071cde0>
>>> torch.exp
<built-in method exp of type object at 0x7596c071cde0>
>>> torch.log
<built-in method log of type object at 0x7596c071cde0>
>>> torch.sin
<built-in method sin of type object at 0x7596c071cde0>
>>> torch.cos
<built-in method cos of type object at 0x7596c071cde0>
>>> torch.tan
<built-in method tan of type object at 0x7596c071cde0>
>>> torch.arcsin
<built-in method arcsin of type object at 0x7596c071cde0>
>>> torch.arccos
<built-in method arccos of type object at 0x7596c071cde0>
>>> torch.arctan
<built-in method arctan of type object at 0x7596c071cde0>
>>> torch.arctan2
<built-in method arctan2 of type object at 0x7596c071cde0>
>>> torch.sinh
<built-in method sinh of type object at 0x7596c071cde0>
>>> torch.cosh
<built-in method cosh of type object at 0x7596c071cde0>
>>> torch.tanh
<built-in method tanh of type object at 0x7596c071cde0>
>>> torch.arcsinh
<built-in method arcsinh of type object at 0x7596c071cde0>
>>> torch.arccosh
<built-in method arccosh of type object at 0x7596c071cde0>
>>> torch.arctanh
<built-in method arctanh of type object at 0x7596c071cde0>
>>> torch.isclose
<built-in method isclose of type object at 0x7596c071cde0>
```

so they probably don't even need a shim (which SymPy needed).

Below is the start of an implementation, using https://pytorch.org/docs/stable/notes/extending.html#extending-torch-python-api as a guide. PyTorch defines a `__torch_function__` method (see [this investigation](https://github.com/docarray/notes/blob/main/blog/02-this-weeks-in-docarray-01.md#__torch_function__--or-how-to-give-pytorch-a-little-bit-more-confidence)), making it possible to overload without even creating real subclasses of `torch.Tensor`, but I think it's a good idea to make subclasses of `torch.Tensor` because these are mostly-normal feature vectors: they just have a few extra properties and methods.

But then I got to the point where I'd have to wrap all of the functions and remembered that that's where all of the complexity is. Some functions (possibly methods or properties) take 1 input vectors and return a non-vector, others return a vector, while some other functions take 2 input vectors with both kinds of output, I don't think there are any functions that take more than 2, but there are some functions that don't do anything to the vector properties, like a PyTorch function to move data to and from the GPU or change its dtype. (Possible simplification: maybe _all_ vector components can be forced to be float32?)

Some of the functions will have to shuffle the indexes to make them line up. Say, for instance, that you have `featuresA` with `x_index=0, y_index=1` and `featuresB` with `x_index=4, y_index=2`. When you add `featuresA + featuresB`, you'll need to pass

```python
featuresA[..., [0, 1]], featuresB[..., [4, 2]]
```

into the `vector._compute.planar.add.dispatch` function.

So that's where I left the implementation, as a sketch of the idea of interpreting the `axis=-1` dimension of feature arrays as vector components, passing `torch` as the compute functions' `lib`. Considering that each of the different types of functions has to be handled differently before calling compute functions, this is not as easy as I thought (a one-day project), but it's still not a huge project. I'd also like to find out if there's a "market" for this backend: I had _assumed_ that spatial and momentum vector calculations would be useful as (the first) part of an ML model, but I wonder if anyone has any known use-cases.

Also, I have to say that the ML "vector" and "tensor" terminology is incredibly confusing in this context. When we say that a feature-set has 2D, 3D, or 4D spatial or momentum vector components, we have to be sure to not call that feature-set a "feature vector," since that's a different thing.