### PR TITLE
Small fix in the contributor's guide

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -51,13 +51,13 @@ The developer installation of `vector` comes with several options -
 These options can be used with `pip` with the editable (`-e`) mode of installation in the following way -
 
 ```bash
-pip install -e .[dev,test]
+pip install -e ".[dev, test]"
 ```
 
 For example, if you want to install the `docs` dependencies along with the dependencies included above, use -
 
 ```bash
-pip install -e .[dev,test,docs]
+pip install -e ".[dev, test, docs]"
 ```
 
 Furthermore, `vector` can also be installed using `conda`. This installation also requires using a virtual environment -


### PR DESCRIPTION
## Description

**Kindly take a look at [CONTRIBUTING.md](https://github.com/scikit-hep/vector/blob/main/.github/CONTRIBUTING.md).**

_Please describe the purpose of this pull request. Reference and link to any relevant issues or pull requests._

Added missing quotation marks in `pip install -e` command

without `""`:

```
vector % pip install -e .[dev,test]  
zsh: no matches found: .[dev,test]
```

Also, I think, usually the new contributor's try to look for the `CONTRIBUTING.md` in the root directory. So, if there are no major consequences, I can move it from `.github` to the root directory and update all the links pointing to the contributor's guide accordingly, either in this PR or in a separate PR. Please LMK if this would be a helpful change.

Thank you :)

## Checklist

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't any other open Pull Requests for the required change?
- [x] Does your submission pass pre-commit? (`$ pre-commit run --all-files` or `$ nox -s lint`)
- [x] Does your submission pass tests? (`$ pytest` or `$ nox -s tests`)
- [x] Does the documentation build with your changes? (`$ cd docs; make clean; make html` or `$ nox -s docs`)
- [x] Does your submission pass the doctests? (`$ pytest --doctest-plus src/vector/` or `$ nox -s doctests`)

## Before Merging

- [ ] Summarize the commit messages into a brief review of the Pull request.
