### PR TITLE
perf: reduce python overhead for awkward backend

### DIFF
--- a/src/vector/__init__.py
+++ b/src/vector/__init__.py
@@ -76,7 +76,7 @@ except ImportError:
     if not typing.TYPE_CHECKING:
         VectorAwkward = None
 else:
-    from vector.backends.awkward import VectorAwkward
+    from vector.backends.awkward import VectorAwkward, awkward_transform
 
 try:
     import sympy  # type: ignore[import-untyped]
@@ -143,6 +143,7 @@ __all__: tuple[str, ...] = (
     "arr",
     "array",
     "awk",
+    "awkward_transform",
     "dim",
     "obj",
     "register_awkward",

--- a/src/vector/_compute/lorentz/Et.py
+++ b/src/vector/_compute/lorentz/Et.py
@@ -114,7 +114,7 @@ def dispatch(v: typing.Any) -> typing.Any:
     with numpy.errstate(all="ignore"):
         return v._wrap_result(
             _flavor_of(v),
-            function(
+            v._wrap_dispatched_function(function)(
                 v.lib,
                 *v.azimuthal.elements,
                 *v.longitudinal.elements,

--- a/src/vector/_compute/lorentz/Et2.py
+++ b/src/vector/_compute/lorentz/Et2.py
@@ -116,7 +116,7 @@ def dispatch(v: typing.Any) -> typing.Any:
     with numpy.errstate(all="ignore"):
         return v._wrap_result(
             _flavor_of(v),
-            function(
+            v._wrap_dispatched_function(function)(
                 v.lib,
                 *v.azimuthal.elements,
                 *v.longitudinal.elements,

--- a/src/vector/_compute/lorentz/Mt.py
+++ b/src/vector/_compute/lorentz/Mt.py
@@ -110,7 +110,7 @@ def dispatch(v: typing.Any) -> typing.Any:
     with numpy.errstate(all="ignore"):
         return v._wrap_result(
             _flavor_of(v),
-            function(
+            v._wrap_dispatched_function(function)(
                 v.lib,
                 *v.azimuthal.elements,
                 *v.longitudinal.elements,

--- a/src/vector/_compute/lorentz/Mt2.py
+++ b/src/vector/_compute/lorentz/Mt2.py
@@ -111,7 +111,7 @@ def dispatch(v: typing.Any) -> typing.Any:
     with numpy.errstate(all="ignore"):
         return v._wrap_result(
             _flavor_of(v),
-            function(
+            v._wrap_dispatched_function(function)(
                 v.lib,
                 *v.azimuthal.elements,
                 *v.longitudinal.elements,

--- a/src/vector/_compute/lorentz/add.py
+++ b/src/vector/_compute/lorentz/add.py
@@ -201,9 +201,10 @@ def dispatch(v1: typing.Any, v2: typing.Any) -> typing.Any:
         ),
     )
     with numpy.errstate(all="ignore"):
-        return _handler_of(v1, v2)._wrap_result(
+        handler = _handler_of(v1, v2)
+        return handler._wrap_result(
             _flavor_of(v1, v2),
-            function(
+            handler._wrap_dispatched_function(function)(
                 _lib_of(v1, v2),
                 *v1.azimuthal.elements,
                 *v1.longitudinal.elements,

--- a/src/vector/_compute/lorentz/beta.py
+++ b/src/vector/_compute/lorentz/beta.py
@@ -153,7 +153,7 @@ def dispatch(v: typing.Any) -> typing.Any:
     with numpy.errstate(all="ignore"):
         return v._wrap_result(
             _flavor_of(v),
-            function(
+            v._wrap_dispatched_function(function)(
                 v.lib,
                 *v.azimuthal.elements,
                 *v.longitudinal.elements,

--- a/src/vector/_compute/lorentz/boostX_beta.py
+++ b/src/vector/_compute/lorentz/boostX_beta.py
@@ -243,7 +243,7 @@ def dispatch(beta: typing.Any, v: typing.Any) -> typing.Any:
     with numpy.errstate(all="ignore"):
         return v._wrap_result(
             _flavor_of(v),
-            function(
+            v._wrap_dispatched_function(function)(
                 v.lib,
                 beta,
                 *v.azimuthal.elements,

--- a/src/vector/_compute/lorentz/boostX_gamma.py
+++ b/src/vector/_compute/lorentz/boostX_gamma.py
@@ -243,7 +243,7 @@ def dispatch(gamma: typing.Any, v: typing.Any) -> typing.Any:
     with numpy.errstate(all="ignore"):
         return v._wrap_result(
             _flavor_of(v),
-            function(
+            v._wrap_dispatched_function(function)(
                 v.lib,
                 gamma,
                 *v.azimuthal.elements,

--- a/src/vector/_compute/lorentz/boostY_beta.py
+++ b/src/vector/_compute/lorentz/boostY_beta.py
@@ -243,7 +243,7 @@ def dispatch(beta: typing.Any, v: typing.Any) -> typing.Any:
     with numpy.errstate(all="ignore"):
         return v._wrap_result(
             _flavor_of(v),
-            function(
+            v._wrap_dispatched_function(function)(
                 v.lib,
                 beta,
                 *v.azimuthal.elements,

--- a/src/vector/_compute/lorentz/boostY_gamma.py
+++ b/src/vector/_compute/lorentz/boostY_gamma.py
@@ -243,7 +243,7 @@ def dispatch(gamma: typing.Any, v: typing.Any) -> typing.Any:
     with numpy.errstate(all="ignore"):
         return v._wrap_result(
             _flavor_of(v),
-            function(
+            v._wrap_dispatched_function(function)(
                 v.lib,
                 gamma,
                 *v.azimuthal.elements,

--- a/src/vector/_compute/lorentz/boostZ_beta.py
+++ b/src/vector/_compute/lorentz/boostZ_beta.py
@@ -218,7 +218,7 @@ def dispatch(beta: typing.Any, v: typing.Any) -> typing.Any:
     with numpy.errstate(all="ignore"):
         return v._wrap_result(
             _flavor_of(v),
-            function(
+            v._wrap_dispatched_function(function)(
                 v.lib,
                 beta,
                 *v.azimuthal.elements,

--- a/src/vector/_compute/lorentz/boostZ_gamma.py
+++ b/src/vector/_compute/lorentz/boostZ_gamma.py
@@ -218,7 +218,7 @@ def dispatch(gamma: typing.Any, v: typing.Any) -> typing.Any:
     with numpy.errstate(all="ignore"):
         return v._wrap_result(
             _flavor_of(v),
-            function(
+            v._wrap_dispatched_function(function)(
                 v.lib,
                 gamma,
                 *v.azimuthal.elements,

--- a/src/vector/_compute/lorentz/boost_beta3.py
+++ b/src/vector/_compute/lorentz/boost_beta3.py
@@ -391,9 +391,10 @@ def dispatch(v1: typing.Any, v2: typing.Any) -> typing.Any:
         ),
     )
     with numpy.errstate(all="ignore"):
-        return _handler_of(v1, v2)._wrap_result(
+        handler = _handler_of(v1, v2)
+        return handler._wrap_result(
             _flavor_of(v1, v2),
-            function(
+            handler._wrap_dispatched_function(function)(
                 _lib_of(v1, v2),
                 *v1.azimuthal.elements,
                 *v1.longitudinal.elements,

--- a/src/vector/_compute/lorentz/boost_p4.py
+++ b/src/vector/_compute/lorentz/boost_p4.py
@@ -781,9 +781,10 @@ def dispatch(v1: typing.Any, v2: typing.Any) -> typing.Any:
         ),
     )
     with numpy.errstate(all="ignore"):
-        return _handler_of(v1, v2)._wrap_result(
+        handler = _handler_of(v1, v2)
+        return handler._wrap_result(
             _flavor_of(v1, v2),
-            function(
+            handler._wrap_dispatched_function(function)(
                 _lib_of(v1, v2),
                 *v1.azimuthal.elements,
                 *v1.longitudinal.elements,

--- a/src/vector/_compute/lorentz/deltaRapidityPhi.py
+++ b/src/vector/_compute/lorentz/deltaRapidityPhi.py
@@ -110,9 +110,10 @@ def dispatch(
         ),
     )
     with numpy.errstate(all="ignore"):
-        return _handler_of(v1, v2)._wrap_result(
+        handler = _handler_of(v1, v2)
+        return handler._wrap_result(
             _flavor_of(v1, v2),
-            function(
+            handler._wrap_dispatched_function(function)(
                 _lib_of(v1, v2),
                 *v1.azimuthal.elements,
                 *v1.longitudinal.elements,

--- a/src/vector/_compute/lorentz/deltaRapidityPhi2.py
+++ b/src/vector/_compute/lorentz/deltaRapidityPhi2.py
@@ -106,9 +106,10 @@ def dispatch(
         ),
     )
     with numpy.errstate(all="ignore"):
-        return _handler_of(v1, v2)._wrap_result(
+        handler = _handler_of(v1, v2)
+        return handler._wrap_result(
             _flavor_of(v1, v2),
-            function(
+            handler._wrap_dispatched_function(function)(
                 _lib_of(v1, v2),
                 *v1.azimuthal.elements,
                 *v1.longitudinal.elements,

--- a/src/vector/_compute/lorentz/dot.py
+++ b/src/vector/_compute/lorentz/dot.py
@@ -155,9 +155,10 @@ def dispatch(v1: typing.Any, v2: typing.Any) -> typing.Any:
         ),
     )
     with numpy.errstate(all="ignore"):
-        return _handler_of(v1, v2)._wrap_result(
+        handler = _handler_of(v1, v2)
+        return handler._wrap_result(
             _flavor_of(v1, v2),
-            function(
+            handler._wrap_dispatched_function(function)(
                 _lib_of(v1, v2),
                 *v1.azimuthal.elements,
                 *v1.longitudinal.elements,

--- a/src/vector/_compute/lorentz/equal.py
+++ b/src/vector/_compute/lorentz/equal.py
@@ -168,9 +168,10 @@ def dispatch(v1: typing.Any, v2: typing.Any) -> typing.Any:
         ),
     )
     with numpy.errstate(all="ignore"):
-        return _handler_of(v1, v2)._wrap_result(
+        handler = _handler_of(v1, v2)
+        return handler._wrap_result(
             _flavor_of(v1, v2),
-            function(
+            handler._wrap_dispatched_function(function)(
                 _lib_of(v1, v2),
                 *v1.azimuthal.elements,
                 *v1.longitudinal.elements,

--- a/src/vector/_compute/lorentz/gamma.py
+++ b/src/vector/_compute/lorentz/gamma.py
@@ -153,7 +153,7 @@ def dispatch(v: typing.Any) -> typing.Any:
     with numpy.errstate(all="ignore"):
         return v._wrap_result(
             _flavor_of(v),
-            function(
+            v._wrap_dispatched_function(function)(
                 v.lib,
                 *v.azimuthal.elements,
                 *v.longitudinal.elements,

--- a/src/vector/_compute/lorentz/is_lightlike.py
+++ b/src/vector/_compute/lorentz/is_lightlike.py
@@ -68,7 +68,7 @@ def dispatch(tolerance: typing.Any, v: typing.Any) -> typing.Any:
     with numpy.errstate(all="ignore"):
         return v._wrap_result(
             _flavor_of(v),
-            function(
+            v._wrap_dispatched_function(function)(
                 v.lib,
                 tolerance,
                 *v.azimuthal.elements,

--- a/src/vector/_compute/lorentz/is_spacelike.py
+++ b/src/vector/_compute/lorentz/is_spacelike.py
@@ -66,7 +66,7 @@ def dispatch(tolerance: typing.Any, v: typing.Any) -> typing.Any:
     with numpy.errstate(all="ignore"):
         return v._wrap_result(
             _flavor_of(v),
-            function(
+            v._wrap_dispatched_function(function)(
                 v.lib,
                 tolerance,
                 *v.azimuthal.elements,

--- a/src/vector/_compute/lorentz/is_timelike.py
+++ b/src/vector/_compute/lorentz/is_timelike.py
@@ -66,7 +66,7 @@ def dispatch(tolerance: typing.Any, v: typing.Any) -> typing.Any:
     with numpy.errstate(all="ignore"):
         return v._wrap_result(
             _flavor_of(v),
-            function(
+            v._wrap_dispatched_function(function)(
                 v.lib,
                 tolerance,
                 *v.azimuthal.elements,

--- a/src/vector/_compute/lorentz/isclose.py
+++ b/src/vector/_compute/lorentz/isclose.py
@@ -221,9 +221,10 @@ def dispatch(
         ),
     )
     with numpy.errstate(all="ignore"):
-        return _handler_of(v1, v2)._wrap_result(
+        handler = _handler_of(v1, v2)
+        return handler._wrap_result(
             _flavor_of(v1, v2),
-            function(
+            handler._wrap_dispatched_function(function)(
                 _lib_of(v1, v2),
                 rtol,
                 atol,

--- a/src/vector/_compute/lorentz/not_equal.py
+++ b/src/vector/_compute/lorentz/not_equal.py
@@ -168,9 +168,10 @@ def dispatch(v1: typing.Any, v2: typing.Any) -> typing.Any:
         ),
     )
     with numpy.errstate(all="ignore"):
-        return _handler_of(v1, v2)._wrap_result(
+        handler = _handler_of(v1, v2)
+        return handler._wrap_result(
             _flavor_of(v1, v2),
-            function(
+            handler._wrap_dispatched_function(function)(
                 _lib_of(v1, v2),
                 *v1.azimuthal.elements,
                 *v1.longitudinal.elements,

--- a/src/vector/_compute/lorentz/rapidity.py
+++ b/src/vector/_compute/lorentz/rapidity.py
@@ -127,7 +127,7 @@ def dispatch(v: typing.Any) -> typing.Any:
     with numpy.errstate(all="ignore"):
         return v._wrap_result(
             _flavor_of(v),
-            function(
+            v._wrap_dispatched_function(function)(
                 v.lib,
                 *v.azimuthal.elements,
                 *v.longitudinal.elements,

--- a/src/vector/_compute/lorentz/scale.py
+++ b/src/vector/_compute/lorentz/scale.py
@@ -181,7 +181,7 @@ def dispatch(factor: typing.Any, v: typing.Any) -> typing.Any:
     with numpy.errstate(all="ignore"):
         return v._wrap_result(
             _flavor_of(v),
-            function(
+            v._wrap_dispatched_function(function)(
                 v.lib,
                 factor,
                 *v.azimuthal.elements,

--- a/src/vector/_compute/lorentz/subtract.py
+++ b/src/vector/_compute/lorentz/subtract.py
@@ -201,9 +201,10 @@ def dispatch(v1: typing.Any, v2: typing.Any) -> typing.Any:
         ),
     )
     with numpy.errstate(all="ignore"):
-        return _handler_of(v1, v2)._wrap_result(
+        handler = _handler_of(v1, v2)
+        return handler._wrap_result(
             _flavor_of(v1, v2),
-            function(
+            handler._wrap_dispatched_function(function)(
                 _lib_of(v1, v2),
                 *v1.azimuthal.elements,
                 *v1.longitudinal.elements,

--- a/src/vector/_compute/lorentz/t.py
+++ b/src/vector/_compute/lorentz/t.py
@@ -37,12 +37,18 @@ def xy_z_t(lib, x, y, z, t):
     return t
 
 
+xy_z_t.__awkward_transform_allowed__ = False  # type:ignore[attr-defined]
+
+
 def xy_z_tau(lib, x, y, z, tau):
     return lib.sqrt(t2.xy_z_tau(lib, x, y, z, tau))
 
 
 def xy_theta_t(lib, x, y, theta, t):
     return t
+
+
+xy_theta_t.__awkward_transform_allowed__ = False  # type:ignore[attr-defined]
 
 
 def xy_theta_tau(lib, x, y, theta, tau):
@@ -53,12 +59,18 @@ def xy_eta_t(lib, x, y, eta, t):
     return t
 
 
+xy_eta_t.__awkward_transform_allowed__ = False  # type:ignore[attr-defined]
+
+
 def xy_eta_tau(lib, x, y, eta, tau):
     return lib.sqrt(t2.xy_eta_tau(lib, x, y, eta, tau))
 
 
 def rhophi_z_t(lib, rho, phi, z, t):
     return t
+
+
+rhophi_z_t.__awkward_transform_allowed__ = False  # type:ignore[attr-defined]
 
 
 def rhophi_z_tau(lib, rho, phi, z, tau):
@@ -69,12 +81,18 @@ def rhophi_theta_t(lib, rho, phi, theta, t):
     return t
 
 
+rhophi_theta_t.__awkward_transform_allowed__ = False  # type:ignore[attr-defined]
+
+
 def rhophi_theta_tau(lib, rho, phi, theta, tau):
     return lib.sqrt(t2.rhophi_theta_tau(lib, rho, phi, theta, tau))
 
 
 def rhophi_eta_t(lib, rho, phi, eta, t):
     return t
+
+
+rhophi_eta_t.__awkward_transform_allowed__ = False  # type:ignore[attr-defined]
 
 
 def rhophi_eta_tau(lib, rho, phi, eta, tau):

--- a/src/vector/_compute/lorentz/t.py
+++ b/src/vector/_compute/lorentz/t.py
@@ -110,7 +110,7 @@ def dispatch(v: typing.Any) -> typing.Any:
     with numpy.errstate(all="ignore"):
         return v._wrap_result(
             _flavor_of(v),
-            function(
+            v._wrap_dispatched_function(function)(
                 v.lib,
                 *v.azimuthal.elements,
                 *v.longitudinal.elements,

--- a/src/vector/_compute/lorentz/t2.py
+++ b/src/vector/_compute/lorentz/t2.py
@@ -125,7 +125,7 @@ def dispatch(v: typing.Any) -> typing.Any:
     with numpy.errstate(all="ignore"):
         return v._wrap_result(
             _flavor_of(v),
-            function(
+            v._wrap_dispatched_function(function)(
                 v.lib,
                 *v.azimuthal.elements,
                 *v.longitudinal.elements,

--- a/src/vector/_compute/lorentz/tau.py
+++ b/src/vector/_compute/lorentz/tau.py
@@ -116,7 +116,7 @@ def dispatch(v: typing.Any) -> typing.Any:
     with numpy.errstate(all="ignore"):
         return v._wrap_result(
             _flavor_of(v),
-            function(
+            v._wrap_dispatched_function(function)(
                 v.lib,
                 *v.azimuthal.elements,
                 *v.longitudinal.elements,

--- a/src/vector/_compute/lorentz/tau.py
+++ b/src/vector/_compute/lorentz/tau.py
@@ -42,6 +42,9 @@ def xy_z_tau(lib, x, y, z, tau):
     return tau
 
 
+xy_z_tau.__awkward_transform_allowed__ = False  # type:ignore[attr-defined]
+
+
 def xy_theta_t(lib, x, y, theta, t):
     squared = tau2.xy_theta_t(lib, x, y, theta, t)
     return lib.copysign(lib.sqrt(lib.absolute(squared)), squared)
@@ -49,6 +52,9 @@ def xy_theta_t(lib, x, y, theta, t):
 
 def xy_theta_tau(lib, x, y, theta, tau):
     return tau
+
+
+xy_theta_tau.__awkward_transform_allowed__ = False  # type:ignore[attr-defined]
 
 
 def xy_eta_t(lib, x, y, eta, t):
@@ -60,6 +66,9 @@ def xy_eta_tau(lib, x, y, eta, tau):
     return tau
 
 
+xy_eta_tau.__awkward_transform_allowed__ = False  # type:ignore[attr-defined]
+
+
 def rhophi_z_t(lib, rho, phi, z, t):
     squared = tau2.rhophi_z_t(lib, rho, phi, z, t)
     return lib.copysign(lib.sqrt(lib.absolute(squared)), squared)
@@ -67,6 +76,9 @@ def rhophi_z_t(lib, rho, phi, z, t):
 
 def rhophi_z_tau(lib, rho, phi, z, tau):
     return tau
+
+
+rhophi_z_tau.__awkward_transform_allowed__ = False  # type:ignore[attr-defined]
 
 
 def rhophi_theta_t(lib, rho, phi, theta, t):
@@ -78,6 +90,9 @@ def rhophi_theta_tau(lib, rho, phi, theta, tau):
     return tau
 
 
+rhophi_theta_tau.__awkward_transform_allowed__ = False  # type:ignore[attr-defined]
+
+
 def rhophi_eta_t(lib, rho, phi, eta, t):
     squared = tau2.rhophi_eta_t(lib, rho, phi, eta, t)
     return lib.copysign(lib.sqrt(lib.absolute(squared)), squared)
@@ -85,6 +100,9 @@ def rhophi_eta_t(lib, rho, phi, eta, t):
 
 def rhophi_eta_tau(lib, rho, phi, eta, tau):
     return tau
+
+
+rhophi_eta_tau.__awkward_transform_allowed__ = False  # type:ignore[attr-defined]
 
 
 dispatch_map = {

--- a/src/vector/_compute/lorentz/tau2.py
+++ b/src/vector/_compute/lorentz/tau2.py
@@ -110,7 +110,7 @@ def dispatch(v: typing.Any) -> typing.Any:
     with numpy.errstate(all="ignore"):
         return v._wrap_result(
             _flavor_of(v),
-            function(
+            v._wrap_dispatched_function(function)(
                 v.lib,
                 *v.azimuthal.elements,
                 *v.longitudinal.elements,

--- a/src/vector/_compute/lorentz/to_beta3.py
+++ b/src/vector/_compute/lorentz/to_beta3.py
@@ -166,7 +166,7 @@ def dispatch(v: typing.Any) -> typing.Any:
     with numpy.errstate(all="ignore"):
         return v._wrap_result(
             _flavor_of(v),
-            function(
+            v._wrap_dispatched_function(function)(
                 v.lib,
                 *v.azimuthal.elements,
                 *v.longitudinal.elements,

--- a/src/vector/_compute/lorentz/transform4D.py
+++ b/src/vector/_compute/lorentz/transform4D.py
@@ -183,7 +183,7 @@ def dispatch(obj: typing.Any, v: typing.Any) -> typing.Any:
     with numpy.errstate(all="ignore"):
         return v._wrap_result(
             _flavor_of(v),
-            function(
+            v._wrap_dispatched_function(function)(
                 v.lib,
                 obj["xx"],
                 obj["xy"],

--- a/src/vector/_compute/lorentz/unit.py
+++ b/src/vector/_compute/lorentz/unit.py
@@ -248,7 +248,7 @@ def dispatch(v: typing.Any) -> typing.Any:
     with numpy.errstate(all="ignore"):
         return v._wrap_result(
             _flavor_of(v),
-            function(
+            v._wrap_dispatched_function(function)(
                 v.lib,
                 *v.azimuthal.elements,
                 *v.longitudinal.elements,

--- a/src/vector/_compute/planar/add.py
+++ b/src/vector/_compute/planar/add.py
@@ -73,9 +73,12 @@ def dispatch(v1: typing.Any, v2: typing.Any) -> typing.Any:
         ),
     )
     with numpy.errstate(all="ignore"):
-        return _handler_of(v1, v2)._wrap_result(
+        handler = _handler_of(v1, v2)
+        return handler._wrap_result(
             _flavor_of(v1, v2),
-            function(_lib_of(v1, v2), *v1.azimuthal.elements, *v2.azimuthal.elements),
+            handler._wrap_dispatched_function(function)(
+                _lib_of(v1, v2), *v1.azimuthal.elements, *v2.azimuthal.elements
+            ),
             returns,
             2,
         )

--- a/src/vector/_compute/planar/deltaphi.py
+++ b/src/vector/_compute/planar/deltaphi.py
@@ -64,9 +64,12 @@ def dispatch(v1: typing.Any, v2: typing.Any) -> typing.Any:
         ),
     )
     with numpy.errstate(all="ignore"):
-        return _handler_of(v1, v2)._wrap_result(
+        handler = _handler_of(v1, v2)
+        return handler._wrap_result(
             _flavor_of(v1, v2),
-            function(_lib_of(v1, v2), *v1.azimuthal.elements, *v2.azimuthal.elements),
+            handler._wrap_dispatched_function(function)(
+                _lib_of(v1, v2), *v1.azimuthal.elements, *v2.azimuthal.elements
+            ),
             returns,
             2,
         )

--- a/src/vector/_compute/planar/dot.py
+++ b/src/vector/_compute/planar/dot.py
@@ -61,9 +61,12 @@ def dispatch(v1: typing.Any, v2: typing.Any) -> typing.Any:
         ),
     )
     with numpy.errstate(all="ignore"):
-        return _handler_of(v1, v2)._wrap_result(
+        handler = _handler_of(v1, v2)
+        return handler._wrap_result(
             _flavor_of(v1, v2),
-            function(_lib_of(v1, v2), *v1.azimuthal.elements, *v2.azimuthal.elements),
+            handler._wrap_dispatched_function(function)(
+                _lib_of(v1, v2), *v1.azimuthal.elements, *v2.azimuthal.elements
+            ),
             returns,
             2,
         )

--- a/src/vector/_compute/planar/equal.py
+++ b/src/vector/_compute/planar/equal.py
@@ -66,9 +66,10 @@ def dispatch(v1: typing.Any, v2: typing.Any) -> typing.Any:
         ),
     )
     with numpy.errstate(all="ignore"):
-        return _handler_of(v1, v2)._wrap_result(
+        handler = _handler_of(v1, v2)
+        return handler._wrap_result(
             _flavor_of(v1, v2),
-            function(
+            handler._wrap_dispatched_function(function)(
                 _lib_of(v1, v2),
                 *v1.azimuthal.elements,
                 *v2.azimuthal.elements,

--- a/src/vector/_compute/planar/is_antiparallel.py
+++ b/src/vector/_compute/planar/is_antiparallel.py
@@ -57,9 +57,10 @@ def dispatch(tolerance: typing.Any, v1: typing.Any, v2: typing.Any) -> typing.An
         ),
     )
     with numpy.errstate(all="ignore"):
-        return _handler_of(v1, v2)._wrap_result(
+        handler = _handler_of(v1, v2)
+        return handler._wrap_result(
             _flavor_of(v1, v2),
-            function(
+            handler._wrap_dispatched_function(function)(
                 _lib_of(v1, v2),
                 tolerance,
                 *v1.azimuthal.elements,

--- a/src/vector/_compute/planar/is_parallel.py
+++ b/src/vector/_compute/planar/is_parallel.py
@@ -57,9 +57,10 @@ def dispatch(tolerance: typing.Any, v1: typing.Any, v2: typing.Any) -> typing.An
         ),
     )
     with numpy.errstate(all="ignore"):
-        return _handler_of(v1, v2)._wrap_result(
+        handler = _handler_of(v1, v2)
+        return handler._wrap_result(
             _flavor_of(v1, v2),
-            function(
+            handler._wrap_dispatched_function(function)(
                 _lib_of(v1, v2),
                 tolerance,
                 *v1.azimuthal.elements,

--- a/src/vector/_compute/planar/is_perpendicular.py
+++ b/src/vector/_compute/planar/is_perpendicular.py
@@ -57,9 +57,10 @@ def dispatch(tolerance: typing.Any, v1: typing.Any, v2: typing.Any) -> typing.An
         ),
     )
     with numpy.errstate(all="ignore"):
-        return _handler_of(v1, v2)._wrap_result(
+        handler = _handler_of(v1, v2)
+        return handler._wrap_result(
             _flavor_of(v1, v2),
-            function(
+            handler._wrap_dispatched_function(function)(
                 _lib_of(v1, v2),
                 tolerance,
                 *v1.azimuthal.elements,

--- a/src/vector/_compute/planar/isclose.py
+++ b/src/vector/_compute/planar/isclose.py
@@ -94,9 +94,10 @@ def dispatch(
         ),
     )
     with numpy.errstate(all="ignore"):
-        return _handler_of(v1, v2)._wrap_result(
+        handler = _handler_of(v1, v2)
+        return handler._wrap_result(
             _flavor_of(v1, v2),
-            function(
+            handler._wrap_dispatched_function(function)(
                 _lib_of(v1, v2),
                 rtol,
                 atol,

--- a/src/vector/_compute/planar/not_equal.py
+++ b/src/vector/_compute/planar/not_equal.py
@@ -66,9 +66,10 @@ def dispatch(v1: typing.Any, v2: typing.Any) -> typing.Any:
         ),
     )
     with numpy.errstate(all="ignore"):
-        return _handler_of(v1, v2)._wrap_result(
+        handler = _handler_of(v1, v2)
+        return handler._wrap_result(
             _flavor_of(v1, v2),
-            function(
+            handler._wrap_dispatched_function(function)(
                 _lib_of(v1, v2),
                 *v1.azimuthal.elements,
                 *v2.azimuthal.elements,

--- a/src/vector/_compute/planar/phi.py
+++ b/src/vector/_compute/planar/phi.py
@@ -43,5 +43,8 @@ def dispatch(v: typing.Any) -> typing.Any:
     function, *returns = _from_signature(__name__, dispatch_map, (_aztype(v),))
     with numpy.errstate(all="ignore"):
         return v._wrap_result(
-            _flavor_of(v), function(v.lib, *v.azimuthal.elements), returns, 1
+            _flavor_of(v),
+            v._wrap_dispatched_function(function)(v.lib, *v.azimuthal.elements),
+            returns,
+            1,
         )

--- a/src/vector/_compute/planar/phi.py
+++ b/src/vector/_compute/planar/phi.py
@@ -33,6 +33,9 @@ def rhophi(lib, rho, phi):
     return phi
 
 
+rhophi.__awkward_transform_allowed__ = False  # type:ignore[attr-defined]
+
+
 dispatch_map = {
     (AzimuthalXY,): (xy, float),
     (AzimuthalRhoPhi,): (rhophi, float),

--- a/src/vector/_compute/planar/rho.py
+++ b/src/vector/_compute/planar/rho.py
@@ -34,6 +34,9 @@ def rhophi(lib, rho, phi):
     return rho
 
 
+rhophi.__awkward_transform_allowed__ = False  # type:ignore[attr-defined]
+
+
 dispatch_map = {
     (AzimuthalXY,): (xy, float),
     (AzimuthalRhoPhi,): (rhophi, float),

--- a/src/vector/_compute/planar/rho.py
+++ b/src/vector/_compute/planar/rho.py
@@ -44,5 +44,8 @@ def dispatch(v: typing.Any) -> typing.Any:
     function, *returns = _from_signature(__name__, dispatch_map, (_aztype(v),))
     with numpy.errstate(all="ignore"):
         return v._wrap_result(
-            _flavor_of(v), function(v.lib, *v.azimuthal.elements), returns, 1
+            _flavor_of(v),
+            v._wrap_dispatched_function(function)(v.lib, *v.azimuthal.elements),
+            returns,
+            1,
         )

--- a/src/vector/_compute/planar/rho2.py
+++ b/src/vector/_compute/planar/rho2.py
@@ -43,5 +43,8 @@ def dispatch(v: typing.Any) -> typing.Any:
     function, *returns = _from_signature(__name__, dispatch_map, (_aztype(v),))
     with numpy.errstate(all="ignore"):
         return v._wrap_result(
-            _flavor_of(v), function(v.lib, *v.azimuthal.elements), returns, 1
+            _flavor_of(v),
+            v._wrap_dispatched_function(function)(v.lib, *v.azimuthal.elements),
+            returns,
+            1,
         )

--- a/src/vector/_compute/planar/rotateZ.py
+++ b/src/vector/_compute/planar/rotateZ.py
@@ -49,7 +49,7 @@ def dispatch(angle: typing.Any, v: typing.Any) -> typing.Any:
     with numpy.errstate(all="ignore"):
         return v._wrap_result(
             _flavor_of(v),
-            function(v.lib, angle, *v.azimuthal.elements),
+            v._wrap_dispatched_function(function)(v.lib, angle, *v.azimuthal.elements),
             returns,
             1,
         )

--- a/src/vector/_compute/planar/scale.py
+++ b/src/vector/_compute/planar/scale.py
@@ -50,7 +50,7 @@ def dispatch(factor: typing.Any, v: typing.Any) -> typing.Any:
     with numpy.errstate(all="ignore"):
         return v._wrap_result(
             _flavor_of(v),
-            function(v.lib, factor, *v.azimuthal.elements),
+            v._wrap_dispatched_function(function)(v.lib, factor, *v.azimuthal.elements),
             returns,
             1,
         )

--- a/src/vector/_compute/planar/subtract.py
+++ b/src/vector/_compute/planar/subtract.py
@@ -73,9 +73,12 @@ def dispatch(v1: typing.Any, v2: typing.Any) -> typing.Any:
         ),
     )
     with numpy.errstate(all="ignore"):
-        return _handler_of(v1, v2)._wrap_result(
+        handler = _handler_of(v1, v2)
+        return handler._wrap_result(
             _flavor_of(v1, v2),
-            function(_lib_of(v1, v2), *v1.azimuthal.elements, *v2.azimuthal.elements),
+            handler._wrap_dispatched_function(function)(
+                _lib_of(v1, v2), *v1.azimuthal.elements, *v2.azimuthal.elements
+            ),
             returns,
             2,
         )

--- a/src/vector/_compute/planar/transform2D.py
+++ b/src/vector/_compute/planar/transform2D.py
@@ -50,7 +50,7 @@ def dispatch(obj: typing.Any, v: typing.Any) -> typing.Any:
     with numpy.errstate(all="ignore"):
         return v._wrap_result(
             _flavor_of(v),
-            function(
+            v._wrap_dispatched_function(function)(
                 v.lib, obj["xx"], obj["xy"], obj["yx"], obj["yy"], *v.azimuthal.elements
             ),
             returns,

--- a/src/vector/_compute/planar/unit.py
+++ b/src/vector/_compute/planar/unit.py
@@ -38,6 +38,9 @@ def rhophi(lib, rho, phi):
     return (1, phi)
 
 
+rhophi.__awkward_transform_allowed__ = False  # type:ignore[attr-defined]
+
+
 dispatch_map = {
     (AzimuthalXY,): (xy, AzimuthalXY),
     (AzimuthalRhoPhi,): (rhophi, AzimuthalRhoPhi),

--- a/src/vector/_compute/planar/unit.py
+++ b/src/vector/_compute/planar/unit.py
@@ -48,5 +48,8 @@ def dispatch(v: typing.Any) -> typing.Any:
     function, *returns = _from_signature(__name__, dispatch_map, (_aztype(v),))
     with numpy.errstate(all="ignore"):
         return v._wrap_result(
-            _flavor_of(v), function(v.lib, *v.azimuthal.elements), returns, 1
+            _flavor_of(v),
+            v._wrap_dispatched_function(function)(v.lib, *v.azimuthal.elements),
+            returns,
+            1,
         )

--- a/src/vector/_compute/planar/x.py
+++ b/src/vector/_compute/planar/x.py
@@ -43,5 +43,8 @@ def dispatch(v: typing.Any) -> typing.Any:
     function, *returns = _from_signature(__name__, dispatch_map, (_aztype(v),))
     with numpy.errstate(all="ignore"):
         return v._wrap_result(
-            _flavor_of(v), function(v.lib, *v.azimuthal.elements), returns, 1
+            _flavor_of(v),
+            v._wrap_dispatched_function(function)(v.lib, *v.azimuthal.elements),
+            returns,
+            1,
         )

--- a/src/vector/_compute/planar/x.py
+++ b/src/vector/_compute/planar/x.py
@@ -29,6 +29,9 @@ def xy(lib, x, y):
     return x
 
 
+xy.__awkward_transform_allowed__ = False  # type:ignore[attr-defined]
+
+
 def rhophi(lib, rho, phi):
     return rho * lib.cos(phi)
 

--- a/src/vector/_compute/planar/y.py
+++ b/src/vector/_compute/planar/y.py
@@ -43,5 +43,8 @@ def dispatch(v: typing.Any) -> typing.Any:
     function, *returns = _from_signature(__name__, dispatch_map, (_aztype(v),))
     with numpy.errstate(all="ignore"):
         return v._wrap_result(
-            _flavor_of(v), function(v.lib, *v.azimuthal.elements), returns, 1
+            _flavor_of(v),
+            v._wrap_dispatched_function(function)(v.lib, *v.azimuthal.elements),
+            returns,
+            1,
         )

--- a/src/vector/_compute/planar/y.py
+++ b/src/vector/_compute/planar/y.py
@@ -29,6 +29,9 @@ def xy(lib, x, y):
     return y
 
 
+xy.__awkward_transform_allowed__ = False  # type:ignore[attr-defined]
+
+
 def rhophi(lib, rho, phi):
     return rho * lib.sin(phi)
 

--- a/src/vector/_compute/spatial/add.py
+++ b/src/vector/_compute/spatial/add.py
@@ -589,9 +589,10 @@ def dispatch(v1: typing.Any, v2: typing.Any) -> typing.Any:
         ),
     )
     with numpy.errstate(all="ignore"):
-        return _handler_of(v1, v2)._wrap_result(
+        handler = _handler_of(v1, v2)
+        return handler._wrap_result(
             _flavor_of(v1, v2),
-            function(
+            handler._wrap_dispatched_function(function)(
                 _lib_of(v1, v2),
                 *v1.azimuthal.elements,
                 *v1.longitudinal.elements,

--- a/src/vector/_compute/spatial/costheta.py
+++ b/src/vector/_compute/spatial/costheta.py
@@ -79,7 +79,9 @@ def dispatch(v: typing.Any) -> typing.Any:
     with numpy.errstate(all="ignore"):
         return v._wrap_result(
             _flavor_of(v),
-            function(v.lib, *v.azimuthal.elements, *v.longitudinal.elements),
+            v._wrap_dispatched_function(function)(
+                v.lib, *v.azimuthal.elements, *v.longitudinal.elements
+            ),
             returns,
             1,
         )

--- a/src/vector/_compute/spatial/cottheta.py
+++ b/src/vector/_compute/spatial/cottheta.py
@@ -78,7 +78,9 @@ def dispatch(v: typing.Any) -> typing.Any:
     with numpy.errstate(all="ignore"):
         return v._wrap_result(
             _flavor_of(v),
-            function(v.lib, *v.azimuthal.elements, *v.longitudinal.elements),
+            v._wrap_dispatched_function(function)(
+                v.lib, *v.azimuthal.elements, *v.longitudinal.elements
+            ),
             returns,
             1,
         )

--- a/src/vector/_compute/spatial/cross.py
+++ b/src/vector/_compute/spatial/cross.py
@@ -136,9 +136,10 @@ def dispatch(v1: typing.Any, v2: typing.Any) -> typing.Any:
         ),
     )
     with numpy.errstate(all="ignore"):
-        return _handler_of(v1, v2)._wrap_result(
+        handler = _handler_of(v1, v2)
+        return handler._wrap_result(
             _flavor_of(v1, v2),
-            function(
+            handler._wrap_dispatched_function(function)(
                 _lib_of(v1, v2),
                 *v1.azimuthal.elements,
                 *v1.longitudinal.elements,

--- a/src/vector/_compute/spatial/deltaR.py
+++ b/src/vector/_compute/spatial/deltaR.py
@@ -342,9 +342,10 @@ def dispatch(v1: typing.Any, v2: typing.Any) -> typing.Any:
         ),
     )
     with numpy.errstate(all="ignore"):
-        return _handler_of(v1, v2)._wrap_result(
+        handler = _handler_of(v1, v2)
+        return handler._wrap_result(
             _flavor_of(v1, v2),
-            function(
+            handler._wrap_dispatched_function(function)(
                 _lib_of(v1, v2),
                 *v1.azimuthal.elements,
                 *v1.longitudinal.elements,

--- a/src/vector/_compute/spatial/deltaR2.py
+++ b/src/vector/_compute/spatial/deltaR2.py
@@ -440,9 +440,10 @@ def dispatch(v1: typing.Any, v2: typing.Any) -> typing.Any:
         ),
     )
     with numpy.errstate(all="ignore"):
-        return _handler_of(v1, v2)._wrap_result(
+        handler = _handler_of(v1, v2)
+        return handler._wrap_result(
             _flavor_of(v1, v2),
-            function(
+            handler._wrap_dispatched_function(function)(
                 _lib_of(v1, v2),
                 *v1.azimuthal.elements,
                 *v1.longitudinal.elements,

--- a/src/vector/_compute/spatial/deltaangle.py
+++ b/src/vector/_compute/spatial/deltaangle.py
@@ -695,9 +695,10 @@ def dispatch(v1: typing.Any, v2: typing.Any) -> typing.Any:
         ),
     )
     with numpy.errstate(all="ignore"):
-        return _handler_of(v1, v2)._wrap_result(
+        handler = _handler_of(v1, v2)
+        return handler._wrap_result(
             _flavor_of(v1, v2),
-            function(
+            handler._wrap_dispatched_function(function)(
                 _lib_of(v1, v2),
                 *v1.azimuthal.elements,
                 *v1.longitudinal.elements,

--- a/src/vector/_compute/spatial/deltaeta.py
+++ b/src/vector/_compute/spatial/deltaeta.py
@@ -328,9 +328,10 @@ def dispatch(v1: typing.Any, v2: typing.Any) -> typing.Any:
         ),
     )
     with numpy.errstate(all="ignore"):
-        return _handler_of(v1, v2)._wrap_result(
+        handler = _handler_of(v1, v2)
+        return handler._wrap_result(
             _flavor_of(v1, v2),
-            function(
+            handler._wrap_dispatched_function(function)(
                 _lib_of(v1, v2),
                 *v1.azimuthal.elements,
                 *v1.longitudinal.elements,

--- a/src/vector/_compute/spatial/dot.py
+++ b/src/vector/_compute/spatial/dot.py
@@ -563,9 +563,10 @@ def dispatch(v1: typing.Any, v2: typing.Any) -> typing.Any:
         ),
     )
     with numpy.errstate(all="ignore"):
-        return _handler_of(v1, v2)._wrap_result(
+        handler = _handler_of(v1, v2)
+        return handler._wrap_result(
             _flavor_of(v1, v2),
-            function(
+            handler._wrap_dispatched_function(function)(
                 _lib_of(v1, v2),
                 *v1.azimuthal.elements,
                 *v1.longitudinal.elements,

--- a/src/vector/_compute/spatial/equal.py
+++ b/src/vector/_compute/spatial/equal.py
@@ -469,9 +469,10 @@ def dispatch(v1: typing.Any, v2: typing.Any) -> typing.Any:
         ),
     )
     with numpy.errstate(all="ignore"):
-        return _handler_of(v1, v2)._wrap_result(
+        handler = _handler_of(v1, v2)
+        return handler._wrap_result(
             _flavor_of(v1, v2),
-            function(
+            handler._wrap_dispatched_function(function)(
                 _lib_of(v1, v2),
                 *v1.azimuthal.elements,
                 *v1.longitudinal.elements,

--- a/src/vector/_compute/spatial/eta.py
+++ b/src/vector/_compute/spatial/eta.py
@@ -88,7 +88,9 @@ def dispatch(v: typing.Any) -> typing.Any:
     with numpy.errstate(all="ignore"):
         return v._wrap_result(
             _flavor_of(v),
-            function(v.lib, *v.azimuthal.elements, *v.longitudinal.elements),
+            v._wrap_dispatched_function(function)(
+                v.lib, *v.azimuthal.elements, *v.longitudinal.elements
+            ),
             returns,
             1,
         )

--- a/src/vector/_compute/spatial/eta.py
+++ b/src/vector/_compute/spatial/eta.py
@@ -49,6 +49,9 @@ def xy_eta(lib, x, y, eta):
     return eta
 
 
+xy_eta.__awkward_transform_allowed__ = False  # type:ignore[attr-defined]
+
+
 def rhophi_z(lib, rho, phi, z):
     return lib.nan_to_num(
         lib.arcsinh(z / rho),
@@ -64,6 +67,9 @@ def rhophi_theta(lib, rho, phi, theta):
 
 def rhophi_eta(lib, rho, phi, eta):
     return eta
+
+
+rhophi_eta.__awkward_transform_allowed__ = False  # type:ignore[attr-defined]
 
 
 dispatch_map = {

--- a/src/vector/_compute/spatial/is_antiparallel.py
+++ b/src/vector/_compute/spatial/is_antiparallel.py
@@ -69,9 +69,10 @@ def dispatch(tolerance: typing.Any, v1: typing.Any, v2: typing.Any) -> typing.An
         ),
     )
     with numpy.errstate(all="ignore"):
-        return _handler_of(v1, v2)._wrap_result(
+        handler = _handler_of(v1, v2)
+        return handler._wrap_result(
             _flavor_of(v1, v2),
-            function(
+            handler._wrap_dispatched_function(function)(
                 _lib_of(v1, v2),
                 tolerance,
                 *v1.azimuthal.elements,

--- a/src/vector/_compute/spatial/is_parallel.py
+++ b/src/vector/_compute/spatial/is_parallel.py
@@ -69,9 +69,10 @@ def dispatch(tolerance: typing.Any, v1: typing.Any, v2: typing.Any) -> typing.An
         ),
     )
     with numpy.errstate(all="ignore"):
-        return _handler_of(v1, v2)._wrap_result(
+        handler = _handler_of(v1, v2)
+        return handler._wrap_result(
             _flavor_of(v1, v2),
-            function(
+            handler._wrap_dispatched_function(function)(
                 _lib_of(v1, v2),
                 tolerance,
                 *v1.azimuthal.elements,

--- a/src/vector/_compute/spatial/is_perpendicular.py
+++ b/src/vector/_compute/spatial/is_perpendicular.py
@@ -69,9 +69,10 @@ def dispatch(tolerance: typing.Any, v1: typing.Any, v2: typing.Any) -> typing.An
         ),
     )
     with numpy.errstate(all="ignore"):
-        return _handler_of(v1, v2)._wrap_result(
+        handler = _handler_of(v1, v2)
+        return handler._wrap_result(
             _flavor_of(v1, v2),
-            function(
+            handler._wrap_dispatched_function(function)(
                 _lib_of(v1, v2),
                 tolerance,
                 *v1.azimuthal.elements,

--- a/src/vector/_compute/spatial/isclose.py
+++ b/src/vector/_compute/spatial/isclose.py
@@ -677,9 +677,10 @@ def dispatch(
         ),
     )
     with numpy.errstate(all="ignore"):
-        return _handler_of(v1, v2)._wrap_result(
+        handler = _handler_of(v1, v2)
+        return handler._wrap_result(
             _flavor_of(v1, v2),
-            function(
+            handler._wrap_dispatched_function(function)(
                 _lib_of(v1, v2),
                 rtol,
                 atol,

--- a/src/vector/_compute/spatial/mag.py
+++ b/src/vector/_compute/spatial/mag.py
@@ -80,7 +80,9 @@ def dispatch(v: typing.Any) -> typing.Any:
     with numpy.errstate(all="ignore"):
         return v._wrap_result(
             _flavor_of(v),
-            function(v.lib, *v.azimuthal.elements, *v.longitudinal.elements),
+            v._wrap_dispatched_function(function)(
+                v.lib, *v.azimuthal.elements, *v.longitudinal.elements
+            ),
             returns,
             1,
         )

--- a/src/vector/_compute/spatial/mag2.py
+++ b/src/vector/_compute/spatial/mag2.py
@@ -79,7 +79,9 @@ def dispatch(v: typing.Any) -> typing.Any:
     with numpy.errstate(all="ignore"):
         return v._wrap_result(
             _flavor_of(v),
-            function(v.lib, *v.azimuthal.elements, *v.longitudinal.elements),
+            v._wrap_dispatched_function(function)(
+                v.lib, *v.azimuthal.elements, *v.longitudinal.elements
+            ),
             returns,
             1,
         )

--- a/src/vector/_compute/spatial/not_equal.py
+++ b/src/vector/_compute/spatial/not_equal.py
@@ -469,9 +469,10 @@ def dispatch(v1: typing.Any, v2: typing.Any) -> typing.Any:
         ),
     )
     with numpy.errstate(all="ignore"):
-        return _handler_of(v1, v2)._wrap_result(
+        handler = _handler_of(v1, v2)
+        return handler._wrap_result(
             _flavor_of(v1, v2),
-            function(
+            handler._wrap_dispatched_function(function)(
                 _lib_of(v1, v2),
                 *v1.azimuthal.elements,
                 *v1.longitudinal.elements,

--- a/src/vector/_compute/spatial/rotateX.py
+++ b/src/vector/_compute/spatial/rotateX.py
@@ -92,7 +92,9 @@ def dispatch(angle: typing.Any, v: typing.Any) -> typing.Any:
     with numpy.errstate(all="ignore"):
         return v._wrap_result(
             _flavor_of(v),
-            function(v.lib, angle, *v.azimuthal.elements, *v.longitudinal.elements),
+            v._wrap_dispatched_function(function)(
+                v.lib, angle, *v.azimuthal.elements, *v.longitudinal.elements
+            ),
             returns,
             1,
         )

--- a/src/vector/_compute/spatial/rotateY.py
+++ b/src/vector/_compute/spatial/rotateY.py
@@ -92,7 +92,9 @@ def dispatch(angle: typing.Any, v: typing.Any) -> typing.Any:
     with numpy.errstate(all="ignore"):
         return v._wrap_result(
             _flavor_of(v),
-            function(v.lib, angle, *v.azimuthal.elements, *v.longitudinal.elements),
+            v._wrap_dispatched_function(function)(
+                v.lib, angle, *v.azimuthal.elements, *v.longitudinal.elements
+            ),
             returns,
             1,
         )

--- a/src/vector/_compute/spatial/rotate_axis.py
+++ b/src/vector/_compute/spatial/rotate_axis.py
@@ -154,9 +154,10 @@ def dispatch(angle: typing.Any, v1: typing.Any, v2: typing.Any) -> typing.Any:
         ),
     )
     with numpy.errstate(all="ignore"):
-        return _handler_of(v2)._wrap_result(  # note: _handler_of(v2)
+        handler = _handler_of(v2)
+        return handler._wrap_result(  # note: _handler_of(v2)
             _flavor_of(v2),  # note: _flavor_of(v2)
-            function(
+            handler._wrap_dispatched_function(function)(
                 _lib_of(v1, v2),
                 angle,
                 *v1.azimuthal.elements,

--- a/src/vector/_compute/spatial/rotate_euler.py
+++ b/src/vector/_compute/spatial/rotate_euler.py
@@ -291,7 +291,7 @@ def dispatch(
     with numpy.errstate(all="ignore"):
         return v._wrap_result(
             _flavor_of(v),
-            function(
+            v._wrap_dispatched_function(function)(
                 v.lib,
                 phi,
                 theta,

--- a/src/vector/_compute/spatial/rotate_quaternion.py
+++ b/src/vector/_compute/spatial/rotate_quaternion.py
@@ -119,7 +119,7 @@ def dispatch(
     with numpy.errstate(all="ignore"):
         return vec._wrap_result(
             _flavor_of(vec),
-            function(
+            vec._wrap_dispatched_function(function)(
                 vec.lib, u, i, j, k, *vec.azimuthal.elements, *vec.longitudinal.elements
             ),
             returns,

--- a/src/vector/_compute/spatial/scale.py
+++ b/src/vector/_compute/spatial/scale.py
@@ -94,7 +94,9 @@ def dispatch(factor: typing.Any, v: typing.Any) -> typing.Any:
     with numpy.errstate(all="ignore"):
         return v._wrap_result(
             _flavor_of(v),
-            function(v.lib, factor, *v.azimuthal.elements, *v.longitudinal.elements),
+            v._wrap_dispatched_function(function)(
+                v.lib, factor, *v.azimuthal.elements, *v.longitudinal.elements
+            ),
             returns,
             1,
         )

--- a/src/vector/_compute/spatial/subtract.py
+++ b/src/vector/_compute/spatial/subtract.py
@@ -589,9 +589,10 @@ def dispatch(v1: typing.Any, v2: typing.Any) -> typing.Any:
         ),
     )
     with numpy.errstate(all="ignore"):
-        return _handler_of(v1, v2)._wrap_result(
+        handler = _handler_of(v1, v2)
+        return handler._wrap_result(
             _flavor_of(v1, v2),
-            function(
+            handler._wrap_dispatched_function(function)(
                 _lib_of(v1, v2),
                 *v1.azimuthal.elements,
                 *v1.longitudinal.elements,

--- a/src/vector/_compute/spatial/theta.py
+++ b/src/vector/_compute/spatial/theta.py
@@ -76,7 +76,9 @@ def dispatch(v: typing.Any) -> typing.Any:
     with numpy.errstate(all="ignore"):
         return v._wrap_result(
             _flavor_of(v),
-            function(v.lib, *v.azimuthal.elements, *v.longitudinal.elements),
+            v._wrap_dispatched_function(function)(
+                v.lib, *v.azimuthal.elements, *v.longitudinal.elements
+            ),
             returns,
             1,
         )

--- a/src/vector/_compute/spatial/theta.py
+++ b/src/vector/_compute/spatial/theta.py
@@ -38,6 +38,9 @@ def xy_theta(lib, x, y, theta):
     return theta
 
 
+xy_theta.__awkward_transform_allowed__ = False  # type:ignore[attr-defined]
+
+
 def xy_eta(lib, x, y, eta):
     return 2.0 * lib.arctan(lib.exp(-eta))
 
@@ -48,6 +51,9 @@ def rhophi_z(lib, rho, phi, z):
 
 def rhophi_theta(lib, rho, phi, theta):
     return theta
+
+
+rhophi_theta.__awkward_transform_allowed__ = False  # type:ignore[attr-defined]
 
 
 def rhophi_eta(lib, rho, phi, eta):

--- a/src/vector/_compute/spatial/transform3D.py
+++ b/src/vector/_compute/spatial/transform3D.py
@@ -129,7 +129,7 @@ def dispatch(obj: typing.Any, v: typing.Any) -> typing.Any:
     with numpy.errstate(all="ignore"):
         return v._wrap_result(
             _flavor_of(v),
-            function(
+            v._wrap_dispatched_function(function)(
                 v.lib,
                 obj["xx"],
                 obj["xy"],

--- a/src/vector/_compute/spatial/unit.py
+++ b/src/vector/_compute/spatial/unit.py
@@ -102,7 +102,9 @@ def dispatch(v: typing.Any) -> typing.Any:
     with numpy.errstate(all="ignore"):
         return v._wrap_result(
             _flavor_of(v),
-            function(v.lib, *v.azimuthal.elements, *v.longitudinal.elements),
+            v._wrap_dispatched_function(function)(
+                v.lib, *v.azimuthal.elements, *v.longitudinal.elements
+            ),
             returns,
             1,
         )

--- a/src/vector/_compute/spatial/z.py
+++ b/src/vector/_compute/spatial/z.py
@@ -35,6 +35,9 @@ def xy_z(lib, x, y, z):
     return z
 
 
+xy_z.__awkward_transform_allowed__ = False  # type:ignore[attr-defined]
+
+
 def xy_theta(lib, x, y, theta):
     return lib.nan_to_num(
         rho.xy(lib, x, y) / lib.tan(theta), nan=0.0, posinf=inf, neginf=-inf
@@ -47,6 +50,9 @@ def xy_eta(lib, x, y, eta):
 
 def rhophi_z(lib, rho, phi, z):
     return z
+
+
+rhophi_z.__awkward_transform_allowed__ = False  # type:ignore[attr-defined]
 
 
 def rhophi_theta(lib, rho, phi, theta):

--- a/src/vector/_compute/spatial/z.py
+++ b/src/vector/_compute/spatial/z.py
@@ -79,7 +79,9 @@ def dispatch(v: typing.Any) -> typing.Any:
     with numpy.errstate(all="ignore"):
         return v._wrap_result(
             _flavor_of(v),
-            function(v.lib, *v.azimuthal.elements, *v.longitudinal.elements),
+            v._wrap_dispatched_function(function)(
+                v.lib, *v.azimuthal.elements, *v.longitudinal.elements
+            ),
             returns,
             1,
         )

--- a/src/vector/_methods.py
+++ b/src/vector/_methods.py
@@ -172,6 +172,9 @@ class VectorProtocol:
         """
         raise AssertionError
 
+    def _wrap_dispatched_function(self, func: typing.Callable) -> typing.Callable:  # type: ignore[type-arg]
+        raise AssertionError
+
     ProjectionClass2D: type[VectorProtocolPlanar]
     ProjectionClass3D: type[VectorProtocolSpatial]
     ProjectionClass4D: type[VectorProtocolLorentz]

--- a/src/vector/backends/awkward.py
+++ b/src/vector/backends/awkward.py
@@ -32,7 +32,9 @@ manages this non-strictness well.
 
 from __future__ import annotations
 
+import functools
 import numbers
+import operator
 import types
 import typing
 
@@ -966,6 +968,100 @@ class VectorAwkward:
 
         else:
             raise AssertionError(repr(returns))
+
+    def _wrap_dispatched_function(
+        self: AwkwardProtocol,
+        func: typing.Callable,  # type: ignore[type-arg]
+    ) -> typing.Callable:  # type: ignore[type-arg]
+        return awkward_transform(func)
+
+
+_placeholder = object()
+
+
+class bind(functools.partial):  # type: ignore[type-arg]
+    def __call__(self, *args: typing.Any, **keywords: typing.Any) -> typing.Any:
+        keywords = {**self.keywords, **keywords}
+        iargs = iter(args)
+        args = tuple(next(iargs) if arg is _placeholder else arg for arg in self.args)
+        return self.func(*args, *iargs, **keywords)
+
+
+class awkward_transform:
+    """Apply a batch of transformations in a single layout traversal"""
+
+    def __init__(self, func: typing.Callable) -> None:  # type: ignore[type-arg]
+        self.func = func
+
+    def __call__(self, *args: typing.Any, **kwargs: typing.Any) -> typing.Callable:  # type: ignore[type-arg]
+        # only pos args
+        assert not kwargs
+
+        # prepare the function and its args; we;re currently assuming non-nested input args
+        args2bind, awkward_arrays = [], []
+        n_orig_akarrays = 0
+        for arg in args:
+            if isinstance(arg, (ak.highlevel.Array, ak.highlevel.Record)):
+                n_orig_akarrays += 1
+                awkward_arrays.append(arg)
+                args2bind.append(_placeholder)
+            elif ak._regularize.is_array_like(arg):
+                awkward_arrays.append(ak.Array(ak.to_layout(arg)))
+                args2bind.append(_placeholder)
+            else:
+                args2bind.append(arg)
+
+        # this means we're working with awkward-arrays
+        if n_orig_akarrays > 0:
+
+            def transformer(
+                layouts: ak.contents.Content | tuple[ak.contents.Content, ...],
+                **kwargs: typing.Any,
+            ) -> ak.contents.Content:
+                if not isinstance(layouts, tuple):
+                    layouts = (layouts,)
+                if all(layout.is_numpy for layout in layouts):
+                    # setup parameter propagation, taken from awkward's broadcasting machinery
+                    options = kwargs["options"]
+                    rule = options.pop("broadcast_parameters_rule", None)
+                    try:
+                        parameters_factory = (
+                            ak._broadcasting.BROADCAST_RULE_TO_FACTORY_IMPL[rule]
+                        )
+                    except KeyError:
+                        raise ValueError(
+                            f"`broadcast_parameters_rule` should be one of {[str(x) for x in ak._broadcasting.BroadcastParameterRule]}, "
+                            f"but this routine received `{rule}`"
+                        ) from None
+
+                    # apply the function to the numpy arrays, first we need to 'partial it out' all non-awkward array arguments
+                    out_numpys = bind(self.func, *args2bind)(
+                        *(map(operator.attrgetter("data"), layouts))
+                    )
+                    # if the function returns a single array, wrap it in a tuple
+                    if not isinstance(out_numpys, tuple):
+                        out_numpys = (out_numpys,)
+                    # propagate parameters
+                    out_params = parameters_factory(
+                        (layout.parameters for layout in layouts), len(out_numpys)
+                    )
+                    # wrap the numpy arrays in awkward arrays
+                    out_arrays = tuple(
+                        ak.contents.NumpyArray(data=data, parameters=parameters)
+                        for data, parameters in zip(out_numpys, out_params)
+                    )
+                    # if the function returns a single array, return it directly
+                    if len(out_arrays) == 1:
+                        return out_arrays[0]
+                    # return the awkward array(s)
+                    return out_arrays
+
+            # apply to all arrays
+            return ak.transform(transformer, *awkward_arrays)
+        # if we arrived here this is because we're not working with awkward arrays (or have awkward-array installed).
+        # that also means that if we call nested functions that are all decorated with this decorator, we'll end up here,
+        # which is great, because that still means only one awkward broadcasting traversal!
+        return self.func(*args, **kwargs)
 
 
 class VectorAwkward2D(VectorAwkward, Planar, Vector2D):

--- a/src/vector/backends/numpy.py
+++ b/src/vector/backends/numpy.py
@@ -1307,6 +1307,9 @@ class VectorNumpy2D(VectorNumpy, Planar, Vector2D, FloatArray):  # type: ignore[
         else:
             raise AssertionError(repr(returns))
 
+    def _wrap_dispatched_function(self, func: typing.Callable) -> typing.Callable:  # type: ignore[type-arg]
+        return func
+
     def __setitem__(self, where: typing.Any, what: typing.Any) -> None:
         return _setitem(self, where, what, False)
 
@@ -1610,6 +1613,9 @@ class VectorNumpy3D(VectorNumpy, Spatial, Vector3D, FloatArray):  # type: ignore
 
         else:
             raise AssertionError(repr(returns))
+
+    def _wrap_dispatched_function(self, func: typing.Callable) -> typing.Callable:  # type: ignore[type-arg]
+        return func
 
     def __setitem__(self, where: typing.Any, what: typing.Any) -> None:
         return _setitem(self, where, what, False)
@@ -1994,6 +2000,9 @@ class VectorNumpy4D(VectorNumpy, Lorentz, Vector4D, FloatArray):  # type: ignore
 
         else:
             raise AssertionError(repr(returns))
+
+    def _wrap_dispatched_function(self, func: typing.Callable) -> typing.Callable:  # type: ignore[type-arg]
+        return func
 
     def __setitem__(self, where: typing.Any, what: typing.Any) -> None:
         return _setitem(self, where, what, False)

--- a/src/vector/backends/object.py
+++ b/src/vector/backends/object.py
@@ -757,6 +757,9 @@ class VectorObject2D(VectorObject, Planar, Vector2D):
         else:
             raise AssertionError(repr(returns))
 
+    def _wrap_dispatched_function(self, func: typing.Callable) -> typing.Callable:  # type: ignore[type-arg]
+        return func
+
     @property
     def x(self) -> float:
         return super().x
@@ -1157,6 +1160,9 @@ class VectorObject3D(VectorObject, Spatial, Vector3D):
 
         else:
             raise AssertionError(repr(returns))
+
+    def _wrap_dispatched_function(self, func: typing.Callable) -> typing.Callable:  # type: ignore[type-arg]
+        return func
 
     @property
     def x(self) -> float:
@@ -1875,6 +1881,9 @@ class VectorObject4D(VectorObject, Lorentz, Vector4D):
 
         else:
             raise AssertionError(repr(returns))
+
+    def _wrap_dispatched_function(self, func: typing.Callable) -> typing.Callable:  # type: ignore[type-arg]
+        return func
 
     @property
     def x(self) -> float:

--- a/src/vector/backends/sympy.py
+++ b/src/vector/backends/sympy.py
@@ -743,6 +743,9 @@ class VectorSympy2D(VectorSympy, Planar, Vector2D):
         else:
             raise AssertionError(repr(returns))
 
+    def _wrap_dispatched_function(self, func: typing.Callable) -> typing.Callable:  # type: ignore[type-arg]
+        return func
+
 
 class MomentumSympy2D(PlanarMomentum, VectorSympy2D):
     """
@@ -943,6 +946,9 @@ class VectorSympy3D(VectorSympy, Spatial, Vector3D):
 
         else:
             raise AssertionError(repr(returns))
+
+    def _wrap_dispatched_function(self, func: typing.Callable) -> typing.Callable:  # type: ignore[type-arg]
+        return func
 
     @property
     def x(self) -> sympy.Symbol:
@@ -1275,6 +1281,9 @@ class VectorSympy4D(VectorSympy, Lorentz, Vector4D):
 
         else:
             raise AssertionError(repr(returns))
+
+    def _wrap_dispatched_function(self, func: typing.Callable) -> typing.Callable:  # type: ignore[type-arg]
+        return func
 
     @property
     def x(self) -> sympy.Symbol:


### PR DESCRIPTION
Reduce python overhead of awkward-array backend by "grouping" multiple operations into a single broadcasting traversal with `ak.transform`.

## Description

This PR improves the performance of the awkward-array backend by fusing the application of multiple operations (that would each trigger broadcasting every time) into a single broadcast. (This is conceptually similar to fusing GPU kernels to avoid multiple kernel launches, where a kernel launch would be equivalent to a broadcasting with awkward-array - of course, fusing GPU kernels is very much different otherwise...).

 This removes the python overhead significantly, e.g.:

```python
import numpy as np
import awkward as ak

x1 = y1 = z1 = x2 = y2 = z2 = ak.Array([[1, 2, 3], [], None, [4, 5]])

lib = np
angle = 0.3

# an example function that has a lot of operations
from vector._compute.spatial.rotate_axis import cartesian

cartesian(lib, angle, x1, y1, z1, x2, y2, z2)
#(<Array [[1, 2, 3], [], None, [4, 5]] type='4 * option[var * float64]'>,
# <Array [[1, 2, 3], [], None, [4, 5]] type='4 * option[var * float64]'>,
# <Array [[1, 2, 3], [], None, [4, 5]] type='4 * option[var * float64]'>)

%timeit cartesian(lib, angle, x1, y1, z1, x2, y2, z2)
# 17.7 ms ± 33.6 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)

# the following happens now automatically in vector (but it's also exposed to be used somewhere else, e.g. coffea?)
import vector

vector.awkward_transform(cartesian)(lib, angle, x1, y1, z1, x2, y2, z2)
#(<Array [[1, 2, 3], [], None, [4, 5]] type='4 * option[var * float64]'>,
# <Array [[1, 2, 3], [], None, [4, 5]] type='4 * option[var * float64]'>,
# <Array [[1, 2, 3], [], None, [4, 5]] type='4 * option[var * float64]'>)

%timeit vector.awkward_transform(cartesian)(lib, angle, x1, y1, z1, x2, y2, z2)
# 682 μs ± 4.66 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each) 
```

With this PR `vector.awkward_transform` is used internally in vector to speed up all `vector._compute` methods with the awkward backend (through vector's dispatch mechanism).

Note: `vector.awkward_transform` currently makes some assumptions about the internal `vector._compute` methods, e.g. their signature and return signature. This could be written in a general way, but where to stop the generality? At some point input and output arguments would need to be flattened and unflattened similar to JAX PyTrees... and that would be a bit out-of-scope for this decorator. Thus, it is currently exposed in vector's public API, but only intended for expert usage.

Oh, and if someone has a better name for this function/decorator, I'm happy to change it.

## Checklist

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't any other open Pull Requests for the required change?
- [x] Does your submission pass pre-commit? (`$ pre-commit run --all-files` or `$ nox -s lint`)
- [x] Does your submission pass tests? (`$ pytest` or `$ nox -s tests`)
- [x] Does the documentation build with your changes? (`$ cd docs; make clean; make html` or `$ nox -s docs`)
- [x] Does your submission pass the doctests? (`$ pytest --doctest-plus src/vector/` or `$ nox -s doctests`)
