### PR TITLE
docs: add metric and transformation conventions

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -65,7 +65,21 @@ Finally, vectors come in two flavors:
 
 Names and coordinate conventions were chosen to align with [ROOT](https://root.cern/)'s [TLorentzVector](https://root.cern.ch/doc/master/classTLorentzVector.html) and [Math::LorentzVector](https://root.cern.ch/doc/master/classROOT_1_1Math_1_1LorentzVector.html), as well as [scikit-hep/math](https://github.com/scikit-hep/scikit-hep/tree/master/skhep/math), [uproot-methods TLorentzVector](https://github.com/scikit-hep/uproot3-methods/blob/master/uproot3_methods/classes/TLorentzVector.py), [henryiii/hepvector](https://github.com/henryiii/hepvector), and [coffea.nanoevents.methods.vector](https://coffea-hep.readthedocs.io/en/latest/modules/coffea.nanoevents.methods.vector.html).
 
-Vector follows the `(-, -, -, +)` (`x, y, z, t`) metric convention for Lorentz vectors. Further, the transformations and rotations (including boosts) are active, and the Euler angle conventions align with the formalisations in the [GenVector package](https://root.cern/topical/GenVector.pdf).
+Vector follows the $(-, -, -, +)$ (`x, y, z, t`) metric convention for Lorentz vectors. The $(-,-,-,+)$ metric convention for Lorentz vectors corresponds to the Minkowski metric:
+
+```{math}
+g_{\mu\nu} = \text{diag}(-1, -1, -1, +1)
+```
+
+For a Lorentz vector $p^\mu = (p_x, p_y, p_z, E)$, the squared norm (or invariant mass squared) is given by:
+
+```{math}
+p^\mu p_\mu = g_{\mu\nu} p^\mu p^\nu = E^2 - p_x^2 - p_y^2 - p_z^2
+```
+
+This convention is widely used in high-energy physics (HEP), including frameworks such as ROOT.
+
+Further, the transformations and rotations (including boosts) are active, and the Euler angle conventions align with the formalisations in the [GenVector package](https://root.cern/topical/GenVector.pdf). More precisely, the implementation of `rotate_euler` uses the matrices defined in the [wikipedia article](https://en.wikipedia.org/wiki/Euler_angles#Rotation_matrix).
 
 ## Getting help
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -65,7 +65,7 @@ Finally, vectors come in two flavors:
 
 Names and coordinate conventions were chosen to align with [ROOT](https://root.cern/)'s [TLorentzVector](https://root.cern.ch/doc/master/classTLorentzVector.html) and [Math::LorentzVector](https://root.cern.ch/doc/master/classROOT_1_1Math_1_1LorentzVector.html), as well as [scikit-hep/math](https://github.com/scikit-hep/scikit-hep/tree/master/skhep/math), [uproot-methods TLorentzVector](https://github.com/scikit-hep/uproot3-methods/blob/master/uproot3_methods/classes/TLorentzVector.py), [henryiii/hepvector](https://github.com/henryiii/hepvector), and [coffea.nanoevents.methods.vector](https://coffea-hep.readthedocs.io/en/latest/modules/coffea.nanoevents.methods.vector.html).
 
-Vector follows the `(-, -, -, +)` metric convention for Lorentz vectors. Further, the transformations and rotations (including boosts) are active, and the Euler angle conventions align with the formalisations in the [GenVector package](https://root.cern/topical/GenVector.pdf).
+Vector follows the `(-, -, -, +)` (`x, y, z, t`) metric convention for Lorentz vectors. Further, the transformations and rotations (including boosts) are active, and the Euler angle conventions align with the formalisations in the [GenVector package](https://root.cern/topical/GenVector.pdf).
 
 ## Getting help
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -65,6 +65,8 @@ Finally, vectors come in two flavors:
 
 Names and coordinate conventions were chosen to align with [ROOT](https://root.cern/)'s [TLorentzVector](https://root.cern.ch/doc/master/classTLorentzVector.html) and [Math::LorentzVector](https://root.cern.ch/doc/master/classROOT_1_1Math_1_1LorentzVector.html), as well as [scikit-hep/math](https://github.com/scikit-hep/scikit-hep/tree/master/skhep/math), [uproot-methods TLorentzVector](https://github.com/scikit-hep/uproot3-methods/blob/master/uproot3_methods/classes/TLorentzVector.py), [henryiii/hepvector](https://github.com/henryiii/hepvector), and [coffea.nanoevents.methods.vector](https://coffea-hep.readthedocs.io/en/latest/modules/coffea.nanoevents.methods.vector.html).
 
+Vector follows the `(-, -, -, +)` metric convention for Lorentz vectors. Further, the transformations and rotations (including boosts) are active, and the Euler angle conventions align with the formalisations in the [GenVector package](https://root.cern/topical/GenVector.pdf).
+
 ## Getting help
 
 - Source code on GitHub: [scikit-hep/vector](https://github.com/scikit-hep/vector)


### PR DESCRIPTION
## Description

Add metric, transformation and boost, and Euler angle conventions followed by vector (aligned with the ones followed in `ROOT` and `GenVector`).

See https://github.com/openjournals/joss-reviews/issues/7791#issuecomment-2692724384

## Checklist

- [X] Have you followed the guidelines in our Contributing document?
- [X] Have you checked to ensure there aren't any other open Pull Requests for the required change?
- [X] Does your submission pass pre-commit? (`$ pre-commit run --all-files` or `$ nox -s lint`)
- [X] Does your submission pass tests? (`$ pytest` or `$ nox -s tests`)
- [X] Does the documentation build with your changes? (`$ cd docs; make clean; make html` or `$ nox -s docs`)
- [X] Does your submission pass the doctests? (`$ pytest --doctest-plus src/vector/` or `$ nox -s doctests`)

## Before Merging

- [X] Summarize the commit messages into a brief review of the Pull request.
