### PR TITLE
fixing sympy tests  

### DIFF
--- a/tests/compute/sympy/lorentz/test_deltaRapidityPhi.py
+++ b/tests/compute/sympy/lorentz/test_deltaRapidityPhi.py
@@ -28,7 +28,7 @@ def test_lorentz_object():
         vector.backends.sympy.LongitudinalSympyZ(nz),
         vector.backends.sympy.TemporalSympyTau(nt),
     )
-    assert v1.deltaRapidityPhi(v2) == sympy.sqrt(
+    expected = sympy.sqrt(
         0.25
         * (
             -sympy.log(
@@ -47,6 +47,8 @@ def test_lorentz_object():
         )
         ** 2
     )
+
+    assert sympy.simplify(v1.deltaRapidityPhi(v2) - expected) == 0
 
     expected_result = sympy.sqrt(
         # phi

--- a/tests/compute/sympy/lorentz/test_deltaRapidityPhi.py
+++ b/tests/compute/sympy/lorentz/test_deltaRapidityPhi.py
@@ -28,16 +28,16 @@ def test_lorentz_object():
         vector.backends.sympy.LongitudinalSympyZ(nz),
         vector.backends.sympy.TemporalSympyTau(nt),
     )
-    expected = sympy.sqrt(
+    assert v1.deltaRapidityPhi(v2).simplify() == sympy.sqrt(
         0.25
         * (
-            -sympy.log(
-                (nz + sympy.sqrt(nt**2 + nx**2 + ny**2 + nz**2))
-                / (-nz + sympy.sqrt(nt**2 + nx**2 + ny**2 + nz**2))
+            sympy.log(
+                (-nz - sympy.sqrt(nt**2 + nx**2 + ny**2 + nz**2))
+                / (nz - sympy.sqrt(nt**2 + nx**2 + ny**2 + nz**2))
             )
-            + sympy.log(
-                (z + sympy.sqrt(t**2 + x**2 + y**2 + z**2))
-                / (-z + sympy.sqrt(t**2 + x**2 + y**2 + z**2))
+            - sympy.log(
+                (-z - sympy.sqrt(t**2 + x**2 + y**2 + z**2))
+                / (z - sympy.sqrt(t**2 + x**2 + y**2 + z**2))
             )
         )
         ** 2
@@ -47,8 +47,6 @@ def test_lorentz_object():
         )
         ** 2
     )
-
-    assert sympy.simplify(v1.deltaRapidityPhi(v2) - expected) == 0
 
     expected_result = sympy.sqrt(
         # phi

--- a/tests/compute/sympy/lorentz/test_deltaRapidityPhi2.py
+++ b/tests/compute/sympy/lorentz/test_deltaRapidityPhi2.py
@@ -28,9 +28,8 @@ def test_lorentz_sympy():
         vector.backends.sympy.LongitudinalSympyZ(nz),
         vector.backends.sympy.TemporalSympyTau(nt),
     )
-    assert (
-        v1.deltaRapidityPhi2(v2)
-        == 0.25
+    expected = (
+        0.25
         * (
             -sympy.log(
                 (nz + sympy.sqrt(nt**2 + nx**2 + ny**2 + nz**2))
@@ -48,6 +47,8 @@ def test_lorentz_sympy():
         )
         ** 2
     )
+
+    assert sympy.simplify(expected - v1.deltaRapidityPhi2(v2)) == 0
 
     expected_result = (
         # phi

--- a/tests/compute/sympy/lorentz/test_deltaRapidityPhi2.py
+++ b/tests/compute/sympy/lorentz/test_deltaRapidityPhi2.py
@@ -28,16 +28,17 @@ def test_lorentz_sympy():
         vector.backends.sympy.LongitudinalSympyZ(nz),
         vector.backends.sympy.TemporalSympyTau(nt),
     )
-    expected = (
-        0.25
+    assert (
+        v1.deltaRapidityPhi2(v2).simplify()
+        == 0.25
         * (
-            -sympy.log(
-                (nz + sympy.sqrt(nt**2 + nx**2 + ny**2 + nz**2))
-                / (-nz + sympy.sqrt(nt**2 + nx**2 + ny**2 + nz**2))
+            sympy.log(
+                (-nz - sympy.sqrt(nt**2 + nx**2 + ny**2 + nz**2))
+                / (nz - sympy.sqrt(nt**2 + nx**2 + ny**2 + nz**2))
             )
-            + sympy.log(
-                (z + sympy.sqrt(t**2 + x**2 + y**2 + z**2))
-                / (-z + sympy.sqrt(t**2 + x**2 + y**2 + z**2))
+            - sympy.log(
+                (-z - sympy.sqrt(t**2 + x**2 + y**2 + z**2))
+                / (z - sympy.sqrt(t**2 + x**2 + y**2 + z**2))
             )
         )
         ** 2
@@ -47,8 +48,6 @@ def test_lorentz_sympy():
         )
         ** 2
     )
-
-    assert sympy.simplify(expected - v1.deltaRapidityPhi2(v2)) == 0
 
     expected_result = (
         # phi

--- a/tests/compute/sympy/lorentz/test_gamma.py
+++ b/tests/compute/sympy/lorentz/test_gamma.py
@@ -78,7 +78,7 @@ def test_xy_eta_t():
         temporal=vector.backends.sympy.TemporalSympyT(t),
     )
     # TODO: the expression blows up on simplifying?
-    assert vec.gamma == t / sympy.sqrt(
+    expected = t / sympy.sqrt(
         sympy.Abs(
             t**2
             - 0.25
@@ -87,6 +87,7 @@ def test_xy_eta_t():
             * sympy.exp(2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))
         )
     )
+    assert sympy.simplify(vec.gamma - expected) == 0
     assert vec.gamma.subs(values).evalf() == pytest.approx(1.2060453783110545)
 
 
@@ -101,13 +102,14 @@ def test_xy_eta_tau():
         ),
     )
     # TODO: the expression blows up on simplifying?
-    assert vec.gamma == sympy.sqrt(
+    expected = sympy.sqrt(
         0.25
         * (1 + sympy.exp(-2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))) ** 2
         * (x**2 + y**2)
         * sympy.exp(2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))
         + sympy.Abs(-(t**2) + x**2 + y**2 + z**2)
     ) / sympy.sqrt(sympy.Abs(-(t**2) + x**2 + y**2 + z**2))
+    assert sympy.simplify(vec.gamma - expected) == 0
     assert vec.gamma.subs(values).evalf() == pytest.approx(1.2060453783110545)
 
 
@@ -170,7 +172,7 @@ def test_rhophi_eta_t():
         temporal=vector.backends.sympy.TemporalSympyT(t),
     )
     # TODO: the expression blows up on simplifying?
-    assert vec.gamma == t / sympy.sqrt(
+    expected = t / sympy.sqrt(
         sympy.Abs(
             0.25
             * rho**2
@@ -179,6 +181,7 @@ def test_rhophi_eta_t():
             - t**2
         )
     )
+    assert sympy.simplify(vec.gamma - expected) == 0
     assert vec.gamma.subs(values).evalf() == pytest.approx(1.2060453783110545)
 
 
@@ -191,11 +194,12 @@ def test_rhophi_eta_tau():
         ),
     )
     # TODO: the expression blows up on simplifying?
-    assert vec.gamma == sympy.sqrt(
+    expected = sympy.sqrt(
         0.25
         * rho**2
         * (1 + sympy.exp(-2 * sympy.asinh(z / rho))) ** 2
         * sympy.exp(2 * sympy.asinh(z / rho))
         + sympy.Abs(rho**2 - t**2 + z**2)
     ) / sympy.sqrt(sympy.Abs(rho**2 - t**2 + z**2))
+    assert sympy.simplify(vec.gamma - expected) == 0
     assert vec.gamma.subs(values).evalf() == pytest.approx(1.2060453783110545)

--- a/tests/compute/sympy/lorentz/test_gamma.py
+++ b/tests/compute/sympy/lorentz/test_gamma.py
@@ -77,17 +77,15 @@ def test_xy_eta_t():
         ),
         temporal=vector.backends.sympy.TemporalSympyT(t),
     )
-    # TODO: the expression blows up on simplifying?
-    expected = t / sympy.sqrt(
+    assert vec.gamma == t / sympy.sqrt(
         sympy.Abs(
             t**2
-            - 0.25
-            * (1 + sympy.exp(-2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))) ** 2
+            - (0.5 + 0.5 * sympy.exp(-2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2))))
+            ** 2
             * (x**2 + y**2)
             * sympy.exp(2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))
         )
     )
-    assert sympy.simplify(vec.gamma - expected) == 0
     assert vec.gamma.subs(values).evalf() == pytest.approx(1.2060453783110545)
 
 
@@ -101,15 +99,12 @@ def test_xy_eta_tau():
             sympy.sqrt(sympy.Abs(-(t**2) + x**2 + y**2 + z**2))
         ),
     )
-    # TODO: the expression blows up on simplifying?
-    expected = sympy.sqrt(
-        0.25
-        * (1 + sympy.exp(-2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))) ** 2
+    assert vec.gamma == sympy.sqrt(
+        (0.5 + 0.5 * sympy.exp(-2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))) ** 2
         * (x**2 + y**2)
         * sympy.exp(2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))
         + sympy.Abs(-(t**2) + x**2 + y**2 + z**2)
     ) / sympy.sqrt(sympy.Abs(-(t**2) + x**2 + y**2 + z**2))
-    assert sympy.simplify(vec.gamma - expected) == 0
     assert vec.gamma.subs(values).evalf() == pytest.approx(1.2060453783110545)
 
 
@@ -171,17 +166,14 @@ def test_rhophi_eta_t():
         longitudinal=vector.backends.sympy.LongitudinalSympyEta(sympy.asinh(z / rho)),
         temporal=vector.backends.sympy.TemporalSympyT(t),
     )
-    # TODO: the expression blows up on simplifying?
-    expected = t / sympy.sqrt(
+    assert vec.gamma == t / sympy.sqrt(
         sympy.Abs(
-            0.25
-            * rho**2
-            * (1 + sympy.exp(-2 * sympy.asinh(z / rho))) ** 2
+            rho**2
+            * (0.5 + 0.5 * sympy.exp(-2 * sympy.asinh(z / rho))) ** 2
             * sympy.exp(2 * sympy.asinh(z / rho))
             - t**2
         )
     )
-    assert sympy.simplify(vec.gamma - expected) == 0
     assert vec.gamma.subs(values).evalf() == pytest.approx(1.2060453783110545)
 
 
@@ -193,13 +185,10 @@ def test_rhophi_eta_tau():
             sympy.sqrt(sympy.Abs(rho**2 - t**2 + z**2))
         ),
     )
-    # TODO: the expression blows up on simplifying?
-    expected = sympy.sqrt(
-        0.25
-        * rho**2
-        * (1 + sympy.exp(-2 * sympy.asinh(z / rho))) ** 2
+    assert vec.gamma == sympy.sqrt(
+        rho**2
+        * (0.5 + 0.5 * sympy.exp(-2 * sympy.asinh(z / rho))) ** 2
         * sympy.exp(2 * sympy.asinh(z / rho))
         + sympy.Abs(rho**2 - t**2 + z**2)
     ) / sympy.sqrt(sympy.Abs(rho**2 - t**2 + z**2))
-    assert sympy.simplify(vec.gamma - expected) == 0
     assert vec.gamma.subs(values).evalf() == pytest.approx(1.2060453783110545)

--- a/tests/compute/sympy/lorentz/test_rapidity.py
+++ b/tests/compute/sympy/lorentz/test_rapidity.py
@@ -214,7 +214,7 @@ def test_rhophi_eta_tau():
         ),
     )
     # TODO: the expression blows up on simplifying?
-    assert vec.rapidity == 0.5 * sympy.log(
+    expected = 0.5 * sympy.log(
         (
             z
             + sympy.sqrt(
@@ -236,4 +236,5 @@ def test_rhophi_eta_tau():
             )
         )
     )
+    assert sympy.simplify(vec.rapidity - expected) == 0
     assert vec.rapidity.subs(values).evalf() == pytest.approx(0.5493061443340549)

--- a/tests/compute/sympy/lorentz/test_rapidity.py
+++ b/tests/compute/sympy/lorentz/test_rapidity.py
@@ -213,14 +213,12 @@ def test_rhophi_eta_tau():
             sympy.sqrt(sympy.Abs(rho**2 - t**2 + z**2))
         ),
     )
-    # TODO: the expression blows up on simplifying?
-    expected = 0.5 * sympy.log(
+    assert vec.rapidity == 0.5 * sympy.log(
         (
             z
             + sympy.sqrt(
-                0.25
-                * rho**2
-                * (1 + sympy.exp(-2 * sympy.asinh(z / rho))) ** 2
+                rho**2
+                * (0.5 + 0.5 * sympy.exp(-2 * sympy.asinh(z / rho))) ** 2
                 * sympy.exp(2 * sympy.asinh(z / rho))
                 + sympy.Abs(rho**2 - t**2 + z**2)
             )
@@ -228,13 +226,11 @@ def test_rhophi_eta_tau():
         / (
             -z
             + sympy.sqrt(
-                0.25
-                * rho**2
-                * (1 + sympy.exp(-2 * sympy.asinh(z / rho))) ** 2
+                rho**2
+                * (0.5 + 0.5 * sympy.exp(-2 * sympy.asinh(z / rho))) ** 2
                 * sympy.exp(2 * sympy.asinh(z / rho))
                 + sympy.Abs(rho**2 - t**2 + z**2)
             )
         )
     )
-    assert sympy.simplify(vec.rapidity - expected) == 0
     assert vec.rapidity.subs(values).evalf() == pytest.approx(0.5493061443340549)

--- a/tests/compute/sympy/lorentz/test_t.py
+++ b/tests/compute/sympy/lorentz/test_t.py
@@ -92,13 +92,14 @@ def test_xy_eta_tau():
         ),
     )
     # TODO: the expression blows up on simplifying?
-    assert vec.t == sympy.sqrt(
+    expected = sympy.sqrt(
         0.25
         * (1 + sympy.exp(-2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))) ** 2
         * (x**2 + y**2)
         * sympy.exp(2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))
         + sympy.Abs(-(t**2) + x**2 + y**2 + z**2)
     )
+    assert sympy.simplify(vec.t - expected) == 0
     assert vec.t.subs(values).evalf() == pytest.approx(20)
 
 
@@ -173,11 +174,12 @@ def test_rhophi_eta_tau():
         ),
     )
     # TODO: the expression blows up on simplifying?
-    assert vec.t == sympy.sqrt(
+    expected = sympy.sqrt(
         0.25
         * rho**2
         * (1 + sympy.exp(-2 * sympy.asinh(z / rho))) ** 2
         * sympy.exp(2 * sympy.asinh(z / rho))
         + sympy.Abs(rho**2 - t**2 + z**2)
     )
+    assert sympy.simplify(expected - vec.t) == 0
     assert vec.t.subs(values).evalf() == pytest.approx(20)

--- a/tests/compute/sympy/lorentz/test_t.py
+++ b/tests/compute/sympy/lorentz/test_t.py
@@ -91,15 +91,12 @@ def test_xy_eta_tau():
             sympy.sqrt(sympy.Abs(-(t**2) + x**2 + y**2 + z**2))
         ),
     )
-    # TODO: the expression blows up on simplifying?
-    expected = sympy.sqrt(
-        0.25
-        * (1 + sympy.exp(-2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))) ** 2
+    assert vec.t == sympy.sqrt(
+        (0.5 + 0.5 * sympy.exp(-2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))) ** 2
         * (x**2 + y**2)
         * sympy.exp(2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))
         + sympy.Abs(-(t**2) + x**2 + y**2 + z**2)
     )
-    assert sympy.simplify(vec.t - expected) == 0
     assert vec.t.subs(values).evalf() == pytest.approx(20)
 
 
@@ -173,13 +170,10 @@ def test_rhophi_eta_tau():
             sympy.sqrt(sympy.Abs(rho**2 - t**2 + z**2))
         ),
     )
-    # TODO: the expression blows up on simplifying?
-    expected = sympy.sqrt(
-        0.25
-        * rho**2
-        * (1 + sympy.exp(-2 * sympy.asinh(z / rho))) ** 2
+    assert vec.t == sympy.sqrt(
+        rho**2
+        * (0.5 + 0.5 * sympy.exp(-2 * sympy.asinh(z / rho))) ** 2
         * sympy.exp(2 * sympy.asinh(z / rho))
         + sympy.Abs(rho**2 - t**2 + z**2)
     )
-    assert sympy.simplify(expected - vec.t) == 0
     assert vec.t.subs(values).evalf() == pytest.approx(20)

--- a/tests/compute/sympy/lorentz/test_t2.py
+++ b/tests/compute/sympy/lorentz/test_t2.py
@@ -92,11 +92,12 @@ def test_xy_eta_tau():
         ),
     )
     # TODO: the expression blows up on simplifying?
-    assert vec.t2 == 0.25 * (
+    expected = 0.25 * (
         1 + sympy.exp(-2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))
     ) ** 2 * (x**2 + y**2) * sympy.exp(
         2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2))
     ) + sympy.Abs(-(t**2) + x**2 + y**2 + z**2)
+    assert sympy.simplify(vec.t2 - expected) == 0
     assert vec.t2.subs(values).evalf() == pytest.approx(400)
 
 
@@ -167,7 +168,8 @@ def test_rhophi_eta_tau():
         ),
     )
     # TODO: the expression blows up on simplifying?
-    assert vec.t2 == 0.25 * rho**2 * (
+    expected = 0.25 * rho**2 * (
         1 + sympy.exp(-2 * sympy.asinh(z / rho))
     ) ** 2 * sympy.exp(2 * sympy.asinh(z / rho)) + sympy.Abs(rho**2 - t**2 + z**2)
+    assert sympy.simplify(vec.t2 - expected) == 0
     assert vec.t2.subs(values).evalf() == pytest.approx(400)

--- a/tests/compute/sympy/lorentz/test_t2.py
+++ b/tests/compute/sympy/lorentz/test_t2.py
@@ -91,13 +91,11 @@ def test_xy_eta_tau():
             sympy.sqrt(sympy.Abs(-(t**2) + x**2 + y**2 + z**2))
         ),
     )
-    # TODO: the expression blows up on simplifying?
-    expected = 0.25 * (
-        1 + sympy.exp(-2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))
+    assert vec.t2 == (
+        0.5 + 0.5 * sympy.exp(-2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))
     ) ** 2 * (x**2 + y**2) * sympy.exp(
         2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2))
     ) + sympy.Abs(-(t**2) + x**2 + y**2 + z**2)
-    assert sympy.simplify(vec.t2 - expected) == 0
     assert vec.t2.subs(values).evalf() == pytest.approx(400)
 
 
@@ -167,9 +165,7 @@ def test_rhophi_eta_tau():
             sympy.sqrt(sympy.Abs(rho**2 - t**2 + z**2))
         ),
     )
-    # TODO: the expression blows up on simplifying?
-    expected = 0.25 * rho**2 * (
-        1 + sympy.exp(-2 * sympy.asinh(z / rho))
-    ) ** 2 * sympy.exp(2 * sympy.asinh(z / rho)) + sympy.Abs(rho**2 - t**2 + z**2)
-    assert sympy.simplify(vec.t2 - expected) == 0
+    assert vec.t2.simplify() == 0.25 * rho**2 * (4 + 4 * z**2 / rho**2) + sympy.Abs(
+        rho**2 - t**2 + z**2
+    )
     assert vec.t2.subs(values).evalf() == pytest.approx(400)

--- a/tests/compute/sympy/lorentz/test_tau.py
+++ b/tests/compute/sympy/lorentz/test_tau.py
@@ -74,7 +74,7 @@ def test_xy_eta_t():
         vector.backends.sympy.TemporalSympyT(t),
     )
     # TODO: the expression blows up on simplifying?
-    assert vec.tau == sympy.sqrt(
+    expected = sympy.sqrt(
         sympy.Abs(
             t**2
             - 0.25
@@ -83,6 +83,7 @@ def test_xy_eta_t():
             * sympy.exp(2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))
         )
     )
+    assert sympy.simplify(expected - vec.tau) == 0
     assert vec.tau.subs(values).evalf() == pytest.approx(16.583123951777)
 
 

--- a/tests/compute/sympy/lorentz/test_tau.py
+++ b/tests/compute/sympy/lorentz/test_tau.py
@@ -73,17 +73,15 @@ def test_xy_eta_t():
         ),
         vector.backends.sympy.TemporalSympyT(t),
     )
-    # TODO: the expression blows up on simplifying?
-    expected = sympy.sqrt(
+    vec.tau == sympy.sqrt(
         sympy.Abs(
             t**2
-            - 0.25
-            * (1 + sympy.exp(-2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))) ** 2
+            - (0.5 + 0.5 * sympy.exp(-2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2))))
+            ** 2
             * (x**2 + y**2)
             * sympy.exp(2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))
         )
     )
-    assert sympy.simplify(expected - vec.tau) == 0
     assert vec.tau.subs(values).evalf() == pytest.approx(16.583123951777)
 
 

--- a/tests/compute/sympy/lorentz/test_tau.py
+++ b/tests/compute/sympy/lorentz/test_tau.py
@@ -73,7 +73,7 @@ def test_xy_eta_t():
         ),
         vector.backends.sympy.TemporalSympyT(t),
     )
-    vec.tau == sympy.sqrt(
+    assert vec.tau == sympy.sqrt(
         sympy.Abs(
             t**2
             - (0.5 + 0.5 * sympy.exp(-2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2))))

--- a/tests/compute/sympy/lorentz/test_tau2.py
+++ b/tests/compute/sympy/lorentz/test_tau2.py
@@ -74,9 +74,10 @@ def test_xy_eta_t():
         vector.backends.sympy.TemporalSympyT(t),
     )
     # TODO: the expression blows up on simplifying?
-    assert vec.tau2 == t**2 - 0.25 * (
+    expected = t**2 - 0.25 * (
         1 + sympy.exp(-2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))
     ) ** 2 * (x**2 + y**2) * sympy.exp(2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))
+    assert sympy.simplify(expected - vec.tau2) == 0
     assert vec.tau2.subs(values).evalf() == pytest.approx(275)
 
 

--- a/tests/compute/sympy/lorentz/test_tau2.py
+++ b/tests/compute/sympy/lorentz/test_tau2.py
@@ -73,11 +73,9 @@ def test_xy_eta_t():
         ),
         vector.backends.sympy.TemporalSympyT(t),
     )
-    # TODO: the expression blows up on simplifying?
-    expected = t**2 - 0.25 * (
-        1 + sympy.exp(-2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))
+    vec.tau2 == t**2 - (
+        0.5 + 0.5 * sympy.exp(-2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))
     ) ** 2 * (x**2 + y**2) * sympy.exp(2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))
-    assert sympy.simplify(expected - vec.tau2) == 0
     assert vec.tau2.subs(values).evalf() == pytest.approx(275)
 
 

--- a/tests/compute/sympy/lorentz/test_tau2.py
+++ b/tests/compute/sympy/lorentz/test_tau2.py
@@ -73,7 +73,7 @@ def test_xy_eta_t():
         ),
         vector.backends.sympy.TemporalSympyT(t),
     )
-    vec.tau2 == t**2 - (
+    assert vec.tau2 == t**2 - (
         0.5 + 0.5 * sympy.exp(-2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))
     ) ** 2 * (x**2 + y**2) * sympy.exp(2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))
     assert vec.tau2.subs(values).evalf() == pytest.approx(275)

--- a/tests/compute/sympy/lorentz/test_to_beta3.py
+++ b/tests/compute/sympy/lorentz/test_to_beta3.py
@@ -146,20 +146,22 @@ def test_xy_eta_tau():
     assert isinstance(out, vector.backends.sympy.VectorSympy3D)
     assert type(vec.azimuthal) == type(out.azimuthal)  # noqa: E721
     assert type(vec.longitudinal) == type(out.longitudinal)  # noqa: E721
-    assert out.x == x / sympy.sqrt(
+    expected = x / sympy.sqrt(
         0.25
         * (1 + sympy.exp(-2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))) ** 2
         * (x**2 + y**2)
         * sympy.exp(2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))
         + sympy.Abs(-(t**2) + x**2 + y**2 + z**2)
     )
-    assert out.y == y / sympy.sqrt(
+    assert sympy.simplify(out.x - expected) == 0
+    expected = y / sympy.sqrt(
         0.25
         * (1 + sympy.exp(-2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))) ** 2
         * (x**2 + y**2)
         * sympy.exp(2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))
         + sympy.Abs(-(t**2) + x**2 + y**2 + z**2)
     )
+    assert sympy.simplify(expected - out.y) == 0
     # TODO: why won't sympy equate the expressions without double
     # simplifying?
     assert (
@@ -313,23 +315,10 @@ def test_rhophi_eta_tau():
     assert isinstance(out, vector.backends.sympy.VectorSympy3D)
     assert type(vec.azimuthal) == type(out.azimuthal)  # noqa: E721
     assert type(vec.longitudinal) == type(out.longitudinal)  # noqa: E721
-    assert out.x == rho * sympy.cos(phi) / sympy.sqrt(
-        0.25
-        * rho**2
-        * (1 + sympy.exp(-2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))) ** 2
-        * sympy.exp(2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))
-        + sympy.Abs(-(t**2) + x**2 + y**2 + z**2)
-    )
-    assert out.y == rho * sympy.sin(phi) / sympy.sqrt(
-        0.25
-        * rho**2
-        * (1 + sympy.exp(-2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))) ** 2
-        * sympy.exp(2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))
-        + sympy.Abs(-(t**2) + x**2 + y**2 + z**2)
-    )
-    assert out.z == rho * z / (
-        sympy.sqrt(x**2 + y**2)
-        * sympy.sqrt(
+    expected = (
+        rho
+        * sympy.cos(phi)
+        / sympy.sqrt(
             0.25
             * rho**2
             * (1 + sympy.exp(-2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))) ** 2
@@ -337,6 +326,34 @@ def test_rhophi_eta_tau():
             + sympy.Abs(-(t**2) + x**2 + y**2 + z**2)
         )
     )
+    assert sympy.simplify(out.x - expected) == 0
+    expected = (
+        rho
+        * sympy.sin(phi)
+        / sympy.sqrt(
+            0.25
+            * rho**2
+            * (1 + sympy.exp(-2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))) ** 2
+            * sympy.exp(2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))
+            + sympy.Abs(-(t**2) + x**2 + y**2 + z**2)
+        )
+    )
+    assert sympy.simplify(expected - out.y) == 0
+    expected = (
+        rho
+        * z
+        / (
+            sympy.sqrt(x**2 + y**2)
+            * sympy.sqrt(
+                0.25
+                * rho**2
+                * (1 + sympy.exp(-2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))) ** 2
+                * sympy.exp(2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))
+                + sympy.Abs(-(t**2) + x**2 + y**2 + z**2)
+            )
+        )
+    )
+    assert sympy.simplify(expected - out.z) == 0
     assert out.x.subs(values).evalf() == pytest.approx(5 / 20)
     assert out.y.subs(values).evalf() == pytest.approx(0 / 20)
     assert out.z.subs(values).evalf() == pytest.approx(10 / 20)

--- a/tests/compute/sympy/lorentz/test_to_beta3.py
+++ b/tests/compute/sympy/lorentz/test_to_beta3.py
@@ -146,22 +146,18 @@ def test_xy_eta_tau():
     assert isinstance(out, vector.backends.sympy.VectorSympy3D)
     assert type(vec.azimuthal) == type(out.azimuthal)  # noqa: E721
     assert type(vec.longitudinal) == type(out.longitudinal)  # noqa: E721
-    expected = x / sympy.sqrt(
-        0.25
-        * (1 + sympy.exp(-2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))) ** 2
+    assert out.x == x / sympy.sqrt(
+        (0.5 + 0.5 * sympy.exp(-2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))) ** 2
         * (x**2 + y**2)
         * sympy.exp(2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))
         + sympy.Abs(-(t**2) + x**2 + y**2 + z**2)
     )
-    assert sympy.simplify(out.x - expected) == 0
-    expected = y / sympy.sqrt(
-        0.25
-        * (1 + sympy.exp(-2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))) ** 2
+    assert out.y == y / sympy.sqrt(
+        (0.5 + 0.5 * sympy.exp(-2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))) ** 2
         * (x**2 + y**2)
         * sympy.exp(2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))
         + sympy.Abs(-(t**2) + x**2 + y**2 + z**2)
     )
-    assert sympy.simplify(expected - out.y) == 0
     # TODO: why won't sympy equate the expressions without double
     # simplifying?
     assert (
@@ -315,45 +311,28 @@ def test_rhophi_eta_tau():
     assert isinstance(out, vector.backends.sympy.VectorSympy3D)
     assert type(vec.azimuthal) == type(out.azimuthal)  # noqa: E721
     assert type(vec.longitudinal) == type(out.longitudinal)  # noqa: E721
-    expected = (
-        rho
-        * sympy.cos(phi)
-        / sympy.sqrt(
-            0.25
-            * rho**2
-            * (1 + sympy.exp(-2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))) ** 2
+    assert out.x == rho * sympy.cos(phi) / sympy.sqrt(
+        rho**2
+        * (0.5 + 0.5 * sympy.exp(-2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))) ** 2
+        * sympy.exp(2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))
+        + sympy.Abs(-(t**2) + x**2 + y**2 + z**2)
+    )
+    assert out.y == rho * sympy.sin(phi) / sympy.sqrt(
+        rho**2
+        * (0.5 + 0.5 * sympy.exp(-2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))) ** 2
+        * sympy.exp(2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))
+        + sympy.Abs(-(t**2) + x**2 + y**2 + z**2)
+    )
+    assert out.z == rho * z / (
+        sympy.sqrt(x**2 + y**2)
+        * sympy.sqrt(
+            rho**2
+            * (0.5 + 0.5 * sympy.exp(-2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2))))
+            ** 2
             * sympy.exp(2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))
             + sympy.Abs(-(t**2) + x**2 + y**2 + z**2)
         )
     )
-    assert sympy.simplify(out.x - expected) == 0
-    expected = (
-        rho
-        * sympy.sin(phi)
-        / sympy.sqrt(
-            0.25
-            * rho**2
-            * (1 + sympy.exp(-2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))) ** 2
-            * sympy.exp(2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))
-            + sympy.Abs(-(t**2) + x**2 + y**2 + z**2)
-        )
-    )
-    assert sympy.simplify(expected - out.y) == 0
-    expected = (
-        rho
-        * z
-        / (
-            sympy.sqrt(x**2 + y**2)
-            * sympy.sqrt(
-                0.25
-                * rho**2
-                * (1 + sympy.exp(-2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))) ** 2
-                * sympy.exp(2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))
-                + sympy.Abs(-(t**2) + x**2 + y**2 + z**2)
-            )
-        )
-    )
-    assert sympy.simplify(expected - out.z) == 0
     assert out.x.subs(values).evalf() == pytest.approx(5 / 20)
     assert out.y.subs(values).evalf() == pytest.approx(0 / 20)
     assert out.z.subs(values).evalf() == pytest.approx(10 / 20)


### PR DESCRIPTION
## Description

**Kindly take a look at [CONTRIBUTING.md](https://github.com/scikit-hep/vector/blob/main/.github/CONTRIBUTING.md).**

_Please describe the purpose of this pull request. Reference and link to any relevant issues or pull requests._

resolves https://github.com/scikit-hep/vector/issues/579

<details>
  <summary>Failure messages from CI :  https://github.com/scikit-hep/vector/actions/runs/14703378893 </summary>

```
=================================== FAILURES ===================================
_____________________________ test_lorentz_object ______________________________

    def test_lorentz_object():
        v1 = vector.MomentumSympy4D(
            vector.backends.sympy.AzimuthalSympyXY(x, y),
            vector.backends.sympy.LongitudinalSympyZ(z),
            vector.backends.sympy.TemporalSympyTau(t),
        )
        v2 = vector.MomentumSympy4D(
            vector.backends.sympy.AzimuthalSympyXY(nx, ny),
            vector.backends.sympy.LongitudinalSympyZ(nz),
            vector.backends.sympy.TemporalSympyTau(nt),
        )
>       assert v1.deltaRapidityPhi(v2) == sympy.sqrt(
            0.25
            * (
                -sympy.log(
                    (nz + sympy.sqrt(nt**2 + nx**2 + ny**2 + nz**2))
                    / (-nz + sympy.sqrt(nt**2 + nx**2 + ny**2 + nz**2))
                )
                + sympy.log(
                    (z + sympy.sqrt(t**2 + x**2 + y**2 + z**2))
                    / (-z + sympy.sqrt(t**2 + x**2 + y**2 + z**2))
                )
            )
            ** 2
            + (
                sympy.Mod(-sympy.atan2(ny, nx) + sympy.atan2(y, x) + sympy.pi, 2 * sympy.pi)
                - sympy.pi
            )
            ** 2
        )
E       assert sqrt((-0.5*log((nz + sqrt(nt**2 + nx**2 + ny**2 + nz**2))/(-nz + sqrt(nt**2 + nx**2 + ny**2 + nz**2))) + 0.5*log((z + ...2 + y**2 + z**2))/(-z + sqrt(t**2 + x**2 + y**2 + z**2))))**2 + (Mod(-atan2(ny, nx) + atan2(y, x) + pi, 2*pi) - pi)**2) == sqrt(0.25*(-log((nz + sqrt(nt**2 + nx**2 + ny**2 + nz**2))/(-nz + sqrt(nt**2 + nx**2 + ny**2 + nz**2))) + log((z + sqr...2 + y**2 + z**2))/(-z + sqrt(t**2 + x**2 + y**2 + z**2))))**2 + (Mod(-atan2(ny, nx) + atan2(y, x) + pi, 2*pi) - pi)**2)
E        +  where sqrt((-0.5*log((nz + sqrt(nt**2 + nx**2 + ny**2 + nz**2))/(-nz + sqrt(nt**2 + nx**2 + ny**2 + nz**2))) + 0.5*log((z + ...2 + y**2 + z**2))/(-z + sqrt(t**2 + x**2 + y**2 + z**2))))**2 + (Mod(-atan2(ny, nx) + atan2(y, x) + pi, 2*pi) - pi)**2) = deltaRapidityPhi(MomentumSympy4D(px=nx, py=ny, pz=nz, mass=nt))
E        +    where deltaRapidityPhi = MomentumSympy4D(px=x, py=y, pz=z, mass=t).deltaRapidityPhi
E        +  and   sqrt(0.25*(-log((nz + sqrt(nt**2 + nx**2 + ny**2 + nz**2))/(-nz + sqrt(nt**2 + nx**2 + ny**2 + nz**2))) + log((z + sqr...2 + y**2 + z**2))/(-z + sqrt(t**2 + x**2 + y**2 + z**2))))**2 + (Mod(-atan2(ny, nx) + atan2(y, x) + pi, 2*pi) - pi)**2) = <function sqrt at 0x7f3a3ec289a0>(((0.25 * ((-log((nz + sqrt(nt**2 + nx**2 + ny**2 + nz**2))/(-nz + sqrt(nt**2 + nx**2 + ny**2 + nz**2))) + log((z + sqrt(t**2 + x**2 + y**2 + z**2))/(-z + sqrt(t**2 + x**2 + y**2 + z**2)))) ** 2)) + ((Mod(-atan2(ny, nx) + atan2(y, x) + pi, 2*pi) - pi) ** 2)))
E        +    where <function sqrt at 0x7f3a3ec[289](https://github.com/scikit-hep/vector/actions/runs/14703378893/job/41257579268#step:7:290)a0> = sympy.sqrt
E        +    and   log((nz + sqrt(nt**2 + nx**2 + ny**2 + nz**2))/(-nz + sqrt(nt**2 + nx**2 + ny**2 + nz**2))) = log(((nz + sqrt(nt**2 + nx**2 + ny**2 + nz**2)) / (-nz + sqrt(nt**2 + nx**2 + ny**2 + nz**2))))
E        +      where log = sympy.log
E        +      and   sqrt(nt**2 + nx**2 + ny**2 + nz**2) = <function sqrt at 0x7f3a3ec289a0>(((((nt ** 2) + (nx ** 2)) + (ny ** 2)) + (nz ** 2)))
E        +        where <function sqrt at 0x7f3a3ec289a0> = sympy.sqrt
E        +      and   sqrt(nt**2 + nx**2 + ny**2 + nz**2) = <function sqrt at 0x7f3a3ec289a0>(((((nt ** 2) + (nx ** 2)) + (ny ** 2)) + (nz ** 2)))
E        +        where <function sqrt at 0x7f3a3ec289a0> = sympy.sqrt
E        +    and   log((z + sqrt(t**2 + x**2 + y**2 + z**2))/(-z + sqrt(t**2 + x**2 + y**2 + z**2))) = log(((z + sqrt(t**2 + x**2 + y**2 + z**2)) / (-z + sqrt(t**2 + x**2 + y**2 + z**2))))
E        +      where log = sympy.log
E        +      and   sqrt(t**2 + x**2 + y**2 + z**2) = <function sqrt at 0x7f3a3ec289a0>(((((t ** 2) + (x ** 2)) + (y ** 2)) + (z ** 2)))
E        +        where <function sqrt at 0x7f3a3ec289a0> = sympy.sqrt
E        +      and   sqrt(t**2 + x**2 + y**2 + z**2) = <function sqrt at 0x7f3a3ec289a0>(((((t ** 2) + (x ** 2)) + (y ** 2)) + (z ** 2)))
E        +        where <function sqrt at 0x7f3a3ec289a0> = sympy.sqrt
E        +    and   Mod(-atan2(ny, nx) + atan2(y, x) + pi, 2*pi) = Mod(((-atan2(ny, nx) + atan2(y, x)) + pi), (2 * pi))
E        +      where Mod = sympy.Mod
E        +      and   atan2(ny, nx) = atan2(ny, nx)
E        +        where atan2 = sympy.atan2
E        +      and   atan2(y, x) = atan2(y, x)
E        +        where atan2 = sympy.atan2
E        +      and   pi = sympy.pi
E        +      and   pi = sympy.pi
E        +    and   pi = sympy.pi

tests/compute/sympy/lorentz/test_deltaRapidityPhi.py:31: AssertionError
______________________________ test_lorentz_sympy ______________________________

    def test_lorentz_sympy():
        v1 = vector.MomentumSympy4D(
            vector.backends.sympy.AzimuthalSympyXY(x, y),
            vector.backends.sympy.LongitudinalSympyZ(z),
            vector.backends.sympy.TemporalSympyTau(t),
        )
        v2 = vector.MomentumSympy4D(
            vector.backends.sympy.AzimuthalSympyXY(nx, ny),
            vector.backends.sympy.LongitudinalSympyZ(nz),
            vector.backends.sympy.TemporalSympyTau(nt),
        )
>       assert (
            v1.deltaRapidityPhi2(v2)
            == 0.25
            * (
                -sympy.log(
                    (nz + sympy.sqrt(nt**2 + nx**2 + ny**2 + nz**2))
                    / (-nz + sympy.sqrt(nt**2 + nx**2 + ny**2 + nz**2))
                )
                + sympy.log(
                    (z + sympy.sqrt(t**2 + x**2 + y**2 + z**2))
                    / (-z + sympy.sqrt(t**2 + x**2 + y**2 + z**2))
                )
            )
            ** 2
            + (
                sympy.Mod(-sympy.atan2(ny, nx) + sympy.atan2(y, x) + sympy.pi, 2 * sympy.pi)
                - sympy.pi
            )
            ** 2
        )
E       assert (-0.5*log((nz + sqrt(nt**2 + nx**2 + ny**2 + nz**2))/(-nz + sqrt(nt**2 + nx**2 + ny**2 + nz**2))) + 0.5*log((z + sqrt(...*2 + y**2 + z**2))/(-z + sqrt(t**2 + x**2 + y**2 + z**2))))**2 + (Mod(-atan2(ny, nx) + atan2(y, x) + pi, 2*pi) - pi)**2 == ((0.25 * ((-log((nz + sqrt(nt**2 + nx**2 + ny**2 + nz**2))/(-nz + sqrt(nt**2 + nx**2 + ny**2 + nz**2))) + log((z + sqrt(t**2 + x**2 + y**2 + z**2))/(-z + sqrt(t**2 + x**2 + y**2 + z**2)))) ** 2)) + ((Mod(-atan2(ny, nx) + atan2(y, x) + pi, 2*pi) - pi) ** 2))
E        +  where (-0.5*log((nz + sqrt(nt**2 + nx**2 + ny**2 + nz**2))/(-nz + sqrt(nt**2 + nx**2 + ny**2 + nz**2))) + 0.5*log((z + sqrt(...*2 + y**2 + z**2))/(-z + sqrt(t**2 + x**2 + y**2 + z**2))))**2 + (Mod(-atan2(ny, nx) + atan2(y, x) + pi, 2*pi) - pi)**2 = deltaRapidityPhi2(MomentumSympy4D(px=nx, py=ny, pz=nz, mass=nt))
E        +    where deltaRapidityPhi2 = MomentumSympy4D(px=x, py=y, pz=z, mass=t).deltaRapidityPhi2
E        +  and   log((nz + sqrt(nt**2 + nx**2 + ny**2 + nz**2))/(-nz + sqrt(nt**2 + nx**2 + ny**2 + nz**2))) = log(((nz + sqrt(nt**2 + nx**2 + ny**2 + nz**2)) / (-nz + sqrt(nt**2 + nx**2 + ny**2 + nz**2))))
E        +    where log = sympy.log
E        +    and   sqrt(nt**2 + nx**2 + ny**2 + nz**2) = <function sqrt at 0x7f3a3ec289a0>(((((nt ** 2) + (nx ** 2)) + (ny ** 2)) + (nz ** 2)))
E        +      where <function sqrt at 0x7f3a3ec289a0> = sympy.sqrt
E        +    and   sqrt(nt**2 + nx**2 + ny**2 + nz**2) = <function sqrt at 0x7f3a3ec289a0>(((((nt ** 2) + (nx ** 2)) + (ny ** 2)) + (nz ** 2)))
E        +      where <function sqrt at 0x7f3a3ec289a0> = sympy.sqrt
E        +  and   log((z + sqrt(t**2 + x**2 + y**2 + z**2))/(-z + sqrt(t**2 + x**2 + y**2 + z**2))) = log(((z + sqrt(t**2 + x**2 + y**2 + z**2)) / (-z + sqrt(t**2 + x**2 + y**2 + z**2))))
E        +    where log = sympy.log
E        +    and   sqrt(t**2 + x**2 + y**2 + z**2) = <function sqrt at 0x7f3a3ec289a0>(((((t ** 2) + (x ** 2)) + (y ** 2)) + (z ** 2)))
E        +      where <function sqrt at 0x7f3a3ec289a0> = sympy.sqrt
E        +    and   sqrt(t**2 + x**2 + y**2 + z**2) = <function sqrt at 0x7f3a3ec289a0>(((((t ** 2) + (x ** 2)) + (y ** 2)) + (z ** 2)))
E        +      where <function sqrt at 0x7f3a3ec289a0> = sympy.sqrt
E        +  and   Mod(-atan2(ny, nx) + atan2(y, x) + pi, 2*pi) = Mod(((-atan2(ny, nx) + atan2(y, x)) + pi), (2 * pi))
E        +    where Mod = sympy.Mod
E        +    and   atan2(ny, nx) = atan2(ny, nx)
E        +      where atan2 = sympy.atan2
E        +    and   atan2(y, x) = atan2(y, x)
E        +      where atan2 = sympy.atan2
E        +    and   pi = sympy.pi
E        +    and   pi = sympy.pi
E        +  and   pi = sympy.pi

tests/compute/sympy/lorentz/test_deltaRapidityPhi2.py:31: AssertionError
________________________________ test_xy_eta_t _________________________________

    def test_xy_eta_t():
        vec = vector.VectorSympy4D(
            azimuthal=vector.backends.sympy.AzimuthalSympyXY(x, y),
            longitudinal=vector.backends.sympy.LongitudinalSympyEta(
                sympy.asinh(z / sympy.sqrt(x**2 + y**2))
            ),
            temporal=vector.backends.sympy.TemporalSympyT(t),
        )
        # TODO: the expression blows up on simplifying?
>       assert vec.gamma == t / sympy.sqrt(
            sympy.Abs(
                t**2
                - 0.25
                * (1 + sympy.exp(-2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))) ** 2
                * (x**2 + y**2)
                * sympy.exp(2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))
            )
        )
E       assert t/sqrt(Abs(t**2 - (0.5 + 0.5*exp(-2*asinh(z/sqrt(x**2 + y**2))))**2*(x**2 + y**2)*exp(2*asinh(z/sqrt(x**2 + y**2))))) == (t / sqrt(Abs(t**2 - 0.25*(1 + exp(-2*asinh(z/sqrt(x**2 + y**2))))**2*(x**2 + y**2)*exp(2*asinh(z/sqrt(x**2 + y**2))))))
E        +  where t/sqrt(Abs(t**2 - (0.5 + 0.5*exp(-2*asinh(z/sqrt(x**2 + y**2))))**2*(x**2 + y**2)*exp(2*asinh(z/sqrt(x**2 + y**2))))) = VectorSympy4D(x=x, y=y, eta=asinh(z/sqrt(x**2 + y**2)), t=t).gamma
E        +  and   sqrt(Abs(t**2 - 0.25*(1 + exp(-2*asinh(z/sqrt(x**2 + y**2))))**2*(x**2 + y**2)*exp(2*asinh(z/sqrt(x**2 + y**2))))) = <function sqrt at 0x7f3a3ec289a0>(Abs(t**2 - 0.25*(1 + exp(-2*asinh(z/sqrt(x**2 + y**2))))**2*(x**2 + y**2)*exp(2*asinh(z/sqrt(x**2 + y**2)))))
E        +    where <function sqrt at 0x7f3a3ec289a0> = sympy.sqrt
E        +    and   Abs(t**2 - 0.25*(1 + exp(-2*asinh(z/sqrt(x**2 + y**2))))**2*(x**2 + y**2)*exp(2*asinh(z/sqrt(x**2 + y**2)))) = Abs(((t ** 2) - (((0.25 * ((1 + exp(-2*asinh(z/sqrt(x**2 + y**2)))) ** 2)) * ((x ** 2) + (y ** 2))) * exp(2*asinh(z/sqrt(x**2 + y**2))))))
E        +      where Abs = sympy.Abs
E        +      and   exp(-2*asinh(z/sqrt(x**2 + y**2))) = exp((-2 * asinh(z/sqrt(x**2 + y**2))))
E        +        where exp = sympy.exp
E        +        and   asinh(z/sqrt(x**2 + y**2)) = asinh((z / sqrt(x**2 + y**2)))
E        +          where asinh = sympy.asinh
E        +          and   sqrt(x**2 + y**2) = <function sqrt at 0x7f3a3ec289a0>(((x ** 2) + (y ** 2)))
E        +            where <function sqrt at 0x7f3a3ec289a0> = sympy.sqrt
E        +      and   exp(2*asinh(z/sqrt(x**2 + y**2))) = exp((2 * asinh(z/sqrt(x**2 + y**2))))
E        +        where exp = sympy.exp
E        +        and   asinh(z/sqrt(x**2 + y**2)) = asinh((z / sqrt(x**2 + y**2)))
E        +          where asinh = sympy.asinh
E        +          and   sqrt(x**2 + y**2) = <function sqrt at 0x7f3a3ec289a0>(((x ** 2) + (y ** 2)))
E        +            where <function sqrt at 0x7f3a3ec289a0> = sympy.sqrt

tests/compute/sympy/lorentz/test_gamma.py:81: AssertionError
_______________________________ test_xy_eta_tau ________________________________

    def test_xy_eta_tau():
        vec = vector.VectorSympy4D(
            azimuthal=vector.backends.sympy.AzimuthalSympyXY(x, y),
            longitudinal=vector.backends.sympy.LongitudinalSympyEta(
                sympy.asinh(z / sympy.sqrt(x**2 + y**2))
            ),
            temporal=vector.backends.sympy.TemporalSympyTau(
                sympy.sqrt(sympy.Abs(-(t**2) + x**2 + y**2 + z**2))
            ),
        )
        # TODO: the expression blows up on simplifying?
>       assert vec.gamma == sympy.sqrt(
            0.25
            * (1 + sympy.exp(-2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))) ** 2
            * (x**2 + y**2)
            * sympy.exp(2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))
            + sympy.Abs(-(t**2) + x**2 + y**2 + z**2)
        ) / sympy.sqrt(sympy.Abs(-(t**2) + x**2 + y**2 + z**2))
E       assert sqrt((0.5 + 0.5*exp(-2*asinh(z/sqrt(x**2 + y**2))))**2*(x**2 + y**2)*exp(2*asinh(z/sqrt(x**2 + y**2))) + Abs(-t**2 + x**2 + y**2 + z**2))/sqrt(Abs(-t**2 + x**2 + y**2 + z**2)) == (sqrt(0.25*(1 + exp(-2*asinh(z/sqrt(x**2 + y**2))))**2*(x**2 + y**2)*exp(2*asinh(z/sqrt(x**2 + y**2))) + Abs(-t**2 + x**2 + y**2 + z**2)) / sqrt(Abs(-t**2 + x**2 + y**2 + z**2)))
E        +  where sqrt((0.5 + 0.5*exp(-2*asinh(z/sqrt(x**2 + y**2))))**2*(x**2 + y**2)*exp(2*asinh(z/sqrt(x**2 + y**2))) + Abs(-t**2 + x**2 + y**2 + z**2))/sqrt(Abs(-t**2 + x**2 + y**2 + z**2)) = VectorSympy4D(x=x, y=y, eta=asinh(z/sqrt(x**2 + y**2)), tau=sqrt(Abs(-t**2 + x**2 + y**2 + z**2))).gamma
E        +  and   sqrt(0.25*(1 + exp(-2*asinh(z/sqrt(x**2 + y**2))))**2*(x**2 + y**2)*exp(2*asinh(z/sqrt(x**2 + y**2))) + Abs(-t**2 + x**2 + y**2 + z**2)) = <function sqrt at 0x7f3a3ec289a0>(((((0.25 * ((1 + exp(-2*asinh(z/sqrt(x**2 + y**2)))) ** 2)) * ((x ** 2) + (y ** 2))) * exp(2*asinh(z/sqrt(x**2 + y**2)))) + Abs(-t**2 + x**2 + y**2 + z**2)))
E        +    where <function sqrt at 0x7f3a3ec289a0> = sympy.sqrt
E        +    and   exp(-2*asinh(z/sqrt(x**2 + y**2))) = exp((-2 * asinh(z/sqrt(x**2 + y**2))))
E        +      where exp = sympy.exp
E        +      and   asinh(z/sqrt(x**2 + y**2)) = asinh((z / sqrt(x**2 + y**2)))
E        +        where asinh = sympy.asinh
E        +        and   sqrt(x**2 + y**2) = <function sqrt at 0x7f3a3ec289a0>(((x ** 2) + (y ** 2)))
E        +          where <function sqrt at 0x7f3a3ec289a0> = sympy.sqrt
E        +    and   exp(2*asinh(z/sqrt(x**2 + y**2))) = exp((2 * asinh(z/sqrt(x**2 + y**2))))
E        +      where exp = sympy.exp
E        +      and   asinh(z/sqrt(x**2 + y**2)) = asinh((z / sqrt(x**2 + y**2)))
E        +        where asinh = sympy.asinh
E        +        and   sqrt(x**2 + y**2) = <function sqrt at 0x7f3a3ec289a0>(((x ** 2) + (y ** 2)))
E        +          where <function sqrt at 0x7f3a3ec289a0> = sympy.sqrt
E        +    and   Abs(-t**2 + x**2 + y**2 + z**2) = Abs((((-(t ** 2) + (x ** 2)) + (y ** 2)) + (z ** 2)))
E        +      where Abs = sympy.Abs
E        +  and   sqrt(Abs(-t**2 + x**2 + y**2 + z**2)) = <function sqrt at 0x7f3a3ec289a0>(Abs(-t**2 + x**2 + y**2 + z**2))
E        +    where <function sqrt at 0x7f3a3ec289a0> = sympy.sqrt
E        +    and   Abs(-t**2 + x**2 + y**2 + z**2) = Abs((((-(t ** 2) + (x ** 2)) + (y ** 2)) + (z ** 2)))
E        +      where Abs = sympy.Abs

tests/compute/sympy/lorentz/test_gamma.py:104: AssertionError
______________________________ test_rhophi_eta_t _______________________________

    def test_rhophi_eta_t():
        vec = vector.VectorSympy4D(
            azimuthal=vector.backends.sympy.AzimuthalSympyRhoPhi(rho, phi),
            longitudinal=vector.backends.sympy.LongitudinalSympyEta(sympy.asinh(z / rho)),
            temporal=vector.backends.sympy.TemporalSympyT(t),
        )
        # TODO: the expression blows up on simplifying?
>       assert vec.gamma == t / sympy.sqrt(
            sympy.Abs(
                0.25
                * rho**2
                * (1 + sympy.exp(-2 * sympy.asinh(z / rho))) ** 2
                * sympy.exp(2 * sympy.asinh(z / rho))
                - t**2
            )
        )
E       assert t/sqrt(Abs(rho**2*(0.5 + 0.5*exp(-2*asinh(z/rho)))**2*exp(2*asinh(z/rho)) - t**2)) == (t / sqrt(Abs(0.25*rho**2*(1 + exp(-2*asinh(z/rho)))**2*exp(2*asinh(z/rho)) - t**2)))
E        +  where t/sqrt(Abs(rho**2*(0.5 + 0.5*exp(-2*asinh(z/rho)))**2*exp(2*asinh(z/rho)) - t**2)) = VectorSympy4D(rho=rho, phi=phi, eta=asinh(z/rho), t=t).gamma
E        +  and   sqrt(Abs(0.25*rho**2*(1 + exp(-2*asinh(z/rho)))**2*exp(2*asinh(z/rho)) - t**2)) = <function sqrt at 0x7f3a3ec289a0>(Abs(0.25*rho**2*(1 + exp(-2*asinh(z/rho)))**2*exp(2*asinh(z/rho)) - t**2))
E        +    where <function sqrt at 0x7f3a3ec289a0> = sympy.sqrt
E        +    and   Abs(0.25*rho**2*(1 + exp(-2*asinh(z/rho)))**2*exp(2*asinh(z/rho)) - t**2) = Abs(((((0.25 * (rho ** 2)) * ((1 + exp(-2*asinh(z/rho))) ** 2)) * exp(2*asinh(z/rho))) - (t ** 2)))
E        +      where Abs = sympy.Abs
E        +      and   exp(-2*asinh(z/rho)) = exp((-2 * asinh(z/rho)))
E        +        where exp = sympy.exp
E        +        and   asinh(z/rho) = asinh((z / rho))
E        +          where asinh = sympy.asinh
E        +      and   exp(2*asinh(z/rho)) = exp((2 * asinh(z/rho)))
E        +        where exp = sympy.exp
E        +        and   asinh(z/rho) = asinh((z / rho))
E        +          where asinh = sympy.asinh

tests/compute/sympy/lorentz/test_gamma.py:173: AssertionError
_____________________________ test_rhophi_eta_tau ______________________________

    def test_rhophi_eta_tau():
        vec = vector.VectorSympy4D(
            azimuthal=vector.backends.sympy.AzimuthalSympyRhoPhi(rho, phi),
            longitudinal=vector.backends.sympy.LongitudinalSympyEta(sympy.asinh(z / rho)),
            temporal=vector.backends.sympy.TemporalSympyTau(
                sympy.sqrt(sympy.Abs(rho**2 - t**2 + z**2))
            ),
        )
        # TODO: the expression blows up on simplifying?
>       assert vec.gamma == sympy.sqrt(
            0.25
            * rho**2
            * (1 + sympy.exp(-2 * sympy.asinh(z / rho))) ** 2
            * sympy.exp(2 * sympy.asinh(z / rho))
            + sympy.Abs(rho**2 - t**2 + z**2)
        ) / sympy.sqrt(sympy.Abs(rho**2 - t**2 + z**2))
E       assert sqrt(rho**2*(0.5 + 0.5*exp(-2*asinh(z/rho)))**2*exp(2*asinh(z/rho)) + Abs(rho**2 - t**2 + z**2))/sqrt(Abs(rho**2 - t**2 + z**2)) == (sqrt(0.25*rho**2*(1 + exp(-2*asinh(z/rho)))**2*exp(2*asinh(z/rho)) + Abs(rho**2 - t**2 + z**2)) / sqrt(Abs(rho**2 - t**2 + z**2)))
E        +  where sqrt(rho**2*(0.5 + 0.5*exp(-2*asinh(z/rho)))**2*exp(2*asinh(z/rho)) + Abs(rho**2 - t**2 + z**2))/sqrt(Abs(rho**2 - t**2 + z**2)) = VectorSympy4D(rho=rho, phi=phi, eta=asinh(z/rho), tau=sqrt(Abs(rho**2 - t**2 + z**2))).gamma
E        +  and   sqrt(0.25*rho**2*(1 + exp(-2*asinh(z/rho)))**2*exp(2*asinh(z/rho)) + Abs(rho**2 - t**2 + z**2)) = <function sqrt at 0x7f3a3ec289a0>(((((0.25 * (rho ** 2)) * ((1 + exp(-2*asinh(z/rho))) ** 2)) * exp(2*asinh(z/rho))) + Abs(rho**2 - t**2 + z**2)))
E        +    where <function sqrt at 0x7f3a3ec289a0> = sympy.sqrt
E        +    and   exp(-2*asinh(z/rho)) = exp((-2 * asinh(z/rho)))
E        +      where exp = sympy.exp
E        +      and   asinh(z/rho) = asinh((z / rho))
E        +        where asinh = sympy.asinh
E        +    and   exp(2*asinh(z/rho)) = exp((2 * asinh(z/rho)))
E        +      where exp = sympy.exp
E        +      and   asinh(z/rho) = asinh((z / rho))
E        +        where asinh = sympy.asinh
E        +    and   Abs(rho**2 - t**2 + z**2) = Abs((((rho ** 2) - (t ** 2)) + (z ** 2)))
E        +      where Abs = sympy.Abs
E        +  and   sqrt(Abs(rho**2 - t**2 + z**2)) = <function sqrt at 0x7f3a3ec289a0>(Abs(rho**2 - t**2 + z**2))
E        +    where <function sqrt at 0x7f3a3ec289a0> = sympy.sqrt
E        +    and   Abs(rho**2 - t**2 + z**2) = Abs((((rho ** 2) - (t ** 2)) + (z ** 2)))
E        +      where Abs = sympy.Abs

tests/compute/sympy/lorentz/test_gamma.py:194: AssertionError
_____________________________ test_rhophi_eta_tau ______________________________

    def test_rhophi_eta_tau():
        vec = vector.VectorSympy4D(
            vector.backends.sympy.AzimuthalSympyRhoPhi(rho, phi),
            vector.backends.sympy.LongitudinalSympyEta(sympy.asinh(z / rho)),
            vector.backends.sympy.TemporalSympyTau(
                sympy.sqrt(sympy.Abs(rho**2 - t**2 + z**2))
            ),
        )
        # TODO: the expression blows up on simplifying?
>       assert vec.rapidity == 0.5 * sympy.log(
            (
                z
                + sympy.sqrt(
                    0.25
                    * rho**2
                    * (1 + sympy.exp(-2 * sympy.asinh(z / rho))) ** 2
                    * sympy.exp(2 * sympy.asinh(z / rho))
                    + sympy.Abs(rho**2 - t**2 + z**2)
                )
            )
            / (
                -z
                + sympy.sqrt(
                    0.25
                    * rho**2
                    * (1 + sympy.exp(-2 * sympy.asinh(z / rho))) ** 2
                    * sympy.exp(2 * sympy.asinh(z / rho))
                    + sympy.Abs(rho**2 - t**2 + z**2)
                )
            )
        )
E       assert 0.5*log((z + sqrt(rho**2*(0.5 + 0.5*exp(-2*asinh(z/rho)))**2*exp(2*asinh(z/rho)) + Abs(rho**2 - t**2 + z**2)))/(-z + sqrt(rho**2*(0.5 + 0.5*exp(-2*asinh(z/rho)))**2*exp(2*asinh(z/rho)) + Abs(rho**2 - t**2 + z**2)))) == (0.5 * log((z + sqrt(0.25*rho**2*(1 + exp(-2*asinh(z/rho)))**2*exp(2*asinh(z/rho)) + Abs(rho**2 - t**2 + z**2)))/(-z + sqrt(0.25*rho**2*(1 + exp(-2*asinh(z/rho)))**2*exp(2*asinh(z/rho)) + Abs(rho**2 - t**2 + z**2)))))
E        +  where 0.5*log((z + sqrt(rho**2*(0.5 + 0.5*exp(-2*asinh(z/rho)))**2*exp(2*asinh(z/rho)) + Abs(rho**2 - t**2 + z**2)))/(-z + sqrt(rho**2*(0.5 + 0.5*exp(-2*asinh(z/rho)))**2*exp(2*asinh(z/rho)) + Abs(rho**2 - t**2 + z**2)))) = VectorSympy4D(rho=rho, phi=phi, eta=asinh(z/rho), tau=sqrt(Abs(rho**2 - t**2 + z**2))).rapidity
E        +  and   log((z + sqrt(0.25*rho**2*(1 + exp(-2*asinh(z/rho)))**2*exp(2*asinh(z/rho)) + Abs(rho**2 - t**2 + z**2)))/(-z + sqrt(0.25*rho**2*(1 + exp(-2*asinh(z/rho)))**2*exp(2*asinh(z/rho)) + Abs(rho**2 - t**2 + z**2)))) = log(((z + sqrt(0.25*rho**2*(1 + exp(-2*asinh(z/rho)))**2*exp(2*asinh(z/rho)) + Abs(rho**2 - t**2 + z**2))) / (-z + sqrt(0.25*rho**2*(1 + exp(-2*asinh(z/rho)))**2*exp(2*asinh(z/rho)) + Abs(rho**2 - t**2 + z**2)))))
E        +    where log = sympy.log
E        +    and   sqrt(0.25*rho**2*(1 + exp(-2*asinh(z/rho)))**2*exp(2*asinh(z/rho)) + Abs(rho**2 - t**2 + z**2)) = <function sqrt at 0x7f3a3ec289a0>(((((0.25 * (rho ** 2)) * ((1 + exp(-2*asinh(z/rho))) ** 2)) * exp(2*asinh(z/rho))) + Abs(rho**2 - t**2 + z**2)))
E        +      where <function sqrt at 0x7f3a3ec289a0> = sympy.sqrt
E        +      and   exp(-2*asinh(z/rho)) = exp((-2 * asinh(z/rho)))
E        +        where exp = sympy.exp
E        +        and   asinh(z/rho) = asinh((z / rho))
E        +          where asinh = sympy.asinh
E        +      and   exp(2*asinh(z/rho)) = exp((2 * asinh(z/rho)))
E        +        where exp = sympy.exp
E        +        and   asinh(z/rho) = asinh((z / rho))
E        +          where asinh = sympy.asinh
E        +      and   Abs(rho**2 - t**2 + z**2) = Abs((((rho ** 2) - (t ** 2)) + (z ** 2)))
E        +        where Abs = sympy.Abs
E        +    and   sqrt(0.25*rho**2*(1 + exp(-2*asinh(z/rho)))**2*exp(2*asinh(z/rho)) + Abs(rho**2 - t**2 + z**2)) = <function sqrt at 0x7f3a3ec289a0>(((((0.25 * (rho ** 2)) * ((1 + exp(-2*asinh(z/rho))) ** 2)) * exp(2*asinh(z/rho))) + Abs(rho**2 - t**2 + z**2)))
E        +      where <function sqrt at 0x7f3a3ec289a0> = sympy.sqrt
E        +      and   exp(-2*asinh(z/rho)) = exp((-2 * asinh(z/rho)))
E        +        where exp = sympy.exp
E        +        and   asinh(z/rho) = asinh((z / rho))
E        +          where asinh = sympy.asinh
E        +      and   exp(2*asinh(z/rho)) = exp((2 * asinh(z/rho)))
E        +        where exp = sympy.exp
E        +        and   asinh(z/rho) = asinh((z / rho))
E        +          where asinh = sympy.asinh
E        +      and   Abs(rho**2 - t**2 + z**2) = Abs((((rho ** 2) - (t ** 2)) + (z ** 2)))
E        +        where Abs = sympy.Abs

tests/compute/sympy/lorentz/test_rapidity.py:217: AssertionError
_______________________________ test_xy_eta_tau ________________________________

    def test_xy_eta_tau():
        vec = vector.VectorSympy4D(
            vector.backends.sympy.AzimuthalSympyXY(x, y),
            vector.backends.sympy.LongitudinalSympyEta(
                sympy.asinh(z / sympy.sqrt(x**2 + y**2))
            ),
            vector.backends.sympy.TemporalSympyTau(
                sympy.sqrt(sympy.Abs(-(t**2) + x**2 + y**2 + z**2))
            ),
        )
        # TODO: the expression blows up on simplifying?
>       assert vec.t == sympy.sqrt(
            0.25
            * (1 + sympy.exp(-2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))) ** 2
            * (x**2 + y**2)
            * sympy.exp(2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))
            + sympy.Abs(-(t**2) + x**2 + y**2 + z**2)
        )
E       assert sqrt((0.5 + 0.5*exp(-2*asinh(z/sqrt(x**2 + y**2))))**2*(x**2 + y**2)*exp(2*asinh(z/sqrt(x**2 + y**2))) + Abs(-t**2 + x**2 + y**2 + z**2)) == sqrt(0.25*(1 + exp(-2*asinh(z/sqrt(x**2 + y**2))))**2*(x**2 + y**2)*exp(2*asinh(z/sqrt(x**2 + y**2))) + Abs(-t**2 + x**2 + y**2 + z**2))
E        +  where sqrt((0.5 + 0.5*exp(-2*asinh(z/sqrt(x**2 + y**2))))**2*(x**2 + y**2)*exp(2*asinh(z/sqrt(x**2 + y**2))) + Abs(-t**2 + x**2 + y**2 + z**2)) = VectorSympy4D(x=x, y=y, eta=asinh(z/sqrt(x**2 + y**2)), tau=sqrt(Abs(-t**2 + x**2 + y**2 + z**2))).t
E        +  and   sqrt(0.25*(1 + exp(-2*asinh(z/sqrt(x**2 + y**2))))**2*(x**2 + y**2)*exp(2*asinh(z/sqrt(x**2 + y**2))) + Abs(-t**2 + x**2 + y**2 + z**2)) = <function sqrt at 0x7f3a3ec289a0>(((((0.25 * ((1 + exp(-2*asinh(z/sqrt(x**2 + y**2)))) ** 2)) * ((x ** 2) + (y ** 2))) * exp(2*asinh(z/sqrt(x**2 + y**2)))) + Abs(-t**2 + x**2 + y**2 + z**2)))
E        +    where <function sqrt at 0x7f3a3ec289a0> = sympy.sqrt
E        +    and   exp(-2*asinh(z/sqrt(x**2 + y**2))) = exp((-2 * asinh(z/sqrt(x**2 + y**2))))
E        +      where exp = sympy.exp
E        +      and   asinh(z/sqrt(x**2 + y**2)) = asinh((z / sqrt(x**2 + y**2)))
E        +        where asinh = sympy.asinh
E        +        and   sqrt(x**2 + y**2) = <function sqrt at 0x7f3a3ec289a0>(((x ** 2) + (y ** 2)))
E        +          where <function sqrt at 0x7f3a3ec289a0> = sympy.sqrt
E        +    and   exp(2*asinh(z/sqrt(x**2 + y**2))) = exp((2 * asinh(z/sqrt(x**2 + y**2))))
E        +      where exp = sympy.exp
E        +      and   asinh(z/sqrt(x**2 + y**2)) = asinh((z / sqrt(x**2 + y**2)))
E        +        where asinh = sympy.asinh
E        +        and   sqrt(x**2 + y**2) = <function sqrt at 0x7f3a3ec289a0>(((x ** 2) + (y ** 2)))
E        +          where <function sqrt at 0x7f3a3ec289a0> = sympy.sqrt
E        +    and   Abs(-t**2 + x**2 + y**2 + z**2) = Abs((((-(t ** 2) + (x ** 2)) + (y ** 2)) + (z ** 2)))
E        +      where Abs = sympy.Abs

tests/compute/sympy/lorentz/test_t.py:95: AssertionError
_____________________________ test_rhophi_eta_tau ______________________________

    def test_rhophi_eta_tau():
        vec = vector.VectorSympy4D(
            vector.backends.sympy.AzimuthalSympyRhoPhi(rho, phi),
            vector.backends.sympy.LongitudinalSympyEta(sympy.asinh(z / rho)),
            vector.backends.sympy.TemporalSympyTau(
                sympy.sqrt(sympy.Abs(rho**2 - t**2 + z**2))
            ),
        )
        # TODO: the expression blows up on simplifying?
>       assert vec.t == sympy.sqrt(
            0.25
            * rho**2
            * (1 + sympy.exp(-2 * sympy.asinh(z / rho))) ** 2
            * sympy.exp(2 * sympy.asinh(z / rho))
            + sympy.Abs(rho**2 - t**2 + z**2)
        )
E       assert sqrt(rho**2*(0.5 + 0.5*exp(-2*asinh(z/rho)))**2*exp(2*asinh(z/rho)) + Abs(rho**2 - t**2 + z**2)) == sqrt(0.25*rho**2*(1 + exp(-2*asinh(z/rho)))**2*exp(2*asinh(z/rho)) + Abs(rho**2 - t**2 + z**2))
E        +  where sqrt(rho**2*(0.5 + 0.5*exp(-2*asinh(z/rho)))**2*exp(2*asinh(z/rho)) + Abs(rho**2 - t**2 + z**2)) = VectorSympy4D(rho=rho, phi=phi, eta=asinh(z/rho), tau=sqrt(Abs(rho**2 - t**2 + z**2))).t
E        +  and   sqrt(0.25*rho**2*(1 + exp(-2*asinh(z/rho)))**2*exp(2*asinh(z/rho)) + Abs(rho**2 - t**2 + z**2)) = <function sqrt at 0x7f3a3ec289a0>(((((0.25 * (rho ** 2)) * ((1 + exp(-2*asinh(z/rho))) ** 2)) * exp(2*asinh(z/rho))) + Abs(rho**2 - t**2 + z**2)))
E        +    where <function sqrt at 0x7f3a3ec289a0> = sympy.sqrt
E        +    and   exp(-2*asinh(z/rho)) = exp((-2 * asinh(z/rho)))
E        +      where exp = sympy.exp
E        +      and   asinh(z/rho) = asinh((z / rho))
E        +        where asinh = sympy.asinh
E        +    and   exp(2*asinh(z/rho)) = exp((2 * asinh(z/rho)))
E        +      where exp = sympy.exp
E        +      and   asinh(z/rho) = asinh((z / rho))
E        +        where asinh = sympy.asinh
E        +    and   Abs(rho**2 - t**2 + z**2) = Abs((((rho ** 2) - (t ** 2)) + (z ** 2)))
E        +      where Abs = sympy.Abs

tests/compute/sympy/lorentz/test_t.py:176: AssertionError
_______________________________ test_xy_eta_tau ________________________________

    def test_xy_eta_tau():
        vec = vector.VectorSympy4D(
            vector.backends.sympy.AzimuthalSympyXY(x, y),
            vector.backends.sympy.LongitudinalSympyEta(
                sympy.asinh(z / sympy.sqrt(x**2 + y**2))
            ),
            vector.backends.sympy.TemporalSympyTau(
                sympy.sqrt(sympy.Abs(-(t**2) + x**2 + y**2 + z**2))
            ),
        )
        # TODO: the expression blows up on simplifying?
>       assert vec.t2 == 0.25 * (
            1 + sympy.exp(-2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))
        ) ** 2 * (x**2 + y**2) * sympy.exp(
            2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2))
        ) + sympy.Abs(-(t**2) + x**2 + y**2 + z**2)
E       assert (0.5 + 0.5*exp(-2*asinh(z/sqrt(x**2 + y**2))))**2*(x**2 + y**2)*exp(2*asinh(z/sqrt(x**2 + y**2))) + Abs(-t**2 + x**2 + y**2 + z**2) == ((((0.25 * ((1 + exp(-2*asinh(z/sqrt(x**2 + y**2)))) ** 2)) * ((x ** 2) + (y ** 2))) * exp(2*asinh(z/sqrt(x**2 + y**2)))) + Abs(-t**2 + x**2 + y**2 + z**2))
E        +  where (0.5 + 0.5*exp(-2*asinh(z/sqrt(x**2 + y**2))))**2*(x**2 + y**2)*exp(2*asinh(z/sqrt(x**2 + y**2))) + Abs(-t**2 + x**2 + y**2 + z**2) = VectorSympy4D(x=x, y=y, eta=asinh(z/sqrt(x**2 + y**2)), tau=sqrt(Abs(-t**2 + x**2 + y**2 + z**2))).t2
E        +  and   exp(-2*asinh(z/sqrt(x**2 + y**2))) = exp((-2 * asinh(z/sqrt(x**2 + y**2))))
E        +    where exp = sympy.exp
E        +    and   asinh(z/sqrt(x**2 + y**2)) = asinh((z / sqrt(x**2 + y**2)))
E        +      where asinh = sympy.asinh
E        +      and   sqrt(x**2 + y**2) = <function sqrt at 0x7f3a3ec289a0>(((x ** 2) + (y ** 2)))
E        +        where <function sqrt at 0x7f3a3ec289a0> = sympy.sqrt
E        +  and   exp(2*asinh(z/sqrt(x**2 + y**2))) = exp((2 * asinh(z/sqrt(x**2 + y**2))))
E        +    where exp = sympy.exp
E        +    and   asinh(z/sqrt(x**2 + y**2)) = asinh((z / sqrt(x**2 + y**2)))
E        +      where asinh = sympy.asinh
E        +      and   sqrt(x**2 + y**2) = <function sqrt at 0x7f3a3ec289a0>(((x ** 2) + (y ** 2)))
E        +        where <function sqrt at 0x7f3a3ec289a0> = sympy.sqrt
E        +  and   Abs(-t**2 + x**2 + y**2 + z**2) = Abs((((-(t ** 2) + (x ** 2)) + (y ** 2)) + (z ** 2)))
E        +    where Abs = sympy.Abs

tests/compute/sympy/lorentz/test_t2.py:95: AssertionError
_____________________________ test_rhophi_eta_tau ______________________________

    def test_rhophi_eta_tau():
        vec = vector.VectorSympy4D(
            vector.backends.sympy.AzimuthalSympyRhoPhi(rho, phi),
            vector.backends.sympy.LongitudinalSympyEta(sympy.asinh(z / rho)),
            vector.backends.sympy.TemporalSympyTau(
                sympy.sqrt(sympy.Abs(rho**2 - t**2 + z**2))
            ),
        )
        # TODO: the expression blows up on simplifying?
>       assert vec.t2 == 0.25 * rho**2 * (
            1 + sympy.exp(-2 * sympy.asinh(z / rho))
        ) ** 2 * sympy.exp(2 * sympy.asinh(z / rho)) + sympy.Abs(rho**2 - t**2 + z**2)
E       assert rho**2*(0.5 + 0.5*exp(-2*asinh(z/rho)))**2*exp(2*asinh(z/rho)) + Abs(rho**2 - t**2 + z**2) == ((((0.25 * (rho ** 2)) * ((1 + exp(-2*asinh(z/rho))) ** 2)) * exp(2*asinh(z/rho))) + Abs(rho**2 - t**2 + z**2))
E        +  where rho**2*(0.5 + 0.5*exp(-2*asinh(z/rho)))**2*exp(2*asinh(z/rho)) + Abs(rho**2 - t**2 + z**2) = VectorSympy4D(rho=rho, phi=phi, eta=asinh(z/rho), tau=sqrt(Abs(rho**2 - t**2 + z**2))).t2
E        +  and   exp(-2*asinh(z/rho)) = exp((-2 * asinh(z/rho)))
E        +    where exp = sympy.exp
E        +    and   asinh(z/rho) = asinh((z / rho))
E        +      where asinh = sympy.asinh
E        +  and   exp(2*asinh(z/rho)) = exp((2 * asinh(z/rho)))
E        +    where exp = sympy.exp
E        +    and   asinh(z/rho) = asinh((z / rho))
E        +      where asinh = sympy.asinh
E        +  and   Abs(rho**2 - t**2 + z**2) = Abs((((rho ** 2) - (t ** 2)) + (z ** 2)))
E        +    where Abs = sympy.Abs

tests/compute/sympy/lorentz/test_t2.py:170: AssertionError
________________________________ test_xy_eta_t _________________________________

    def test_xy_eta_t():
        vec = vector.VectorSympy4D(
            vector.backends.sympy.AzimuthalSympyXY(x, y),
            vector.backends.sympy.LongitudinalSympyEta(
                sympy.asinh(z / sympy.sqrt(x**2 + y**2))
            ),
            vector.backends.sympy.TemporalSympyT(t),
        )
        # TODO: the expression blows up on simplifying?
>       assert vec.tau == sympy.sqrt(
            sympy.Abs(
                t**2
                - 0.25
                * (1 + sympy.exp(-2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))) ** 2
                * (x**2 + y**2)
                * sympy.exp(2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))
            )
        )
E       assert sqrt(Abs(t**2 - (0.5 + 0.5*exp(-2*asinh(z/sqrt(x**2 + y**2))))**2*(x**2 + y**2)*exp(2*asinh(z/sqrt(x**2 + y**2))))) == sqrt(Abs(t**2 - 0.25*(1 + exp(-2*asinh(z/sqrt(x**2 + y**2))))**2*(x**2 + y**2)*exp(2*asinh(z/sqrt(x**2 + y**2)))))
E        +  where sqrt(Abs(t**2 - (0.5 + 0.5*exp(-2*asinh(z/sqrt(x**2 + y**2))))**2*(x**2 + y**2)*exp(2*asinh(z/sqrt(x**2 + y**2))))) = VectorSympy4D(x=x, y=y, eta=asinh(z/sqrt(x**2 + y**2)), t=t).tau
E        +  and   sqrt(Abs(t**2 - 0.25*(1 + exp(-2*asinh(z/sqrt(x**2 + y**2))))**2*(x**2 + y**2)*exp(2*asinh(z/sqrt(x**2 + y**2))))) = <function sqrt at 0x7f3a3ec289a0>(Abs(t**2 - 0.25*(1 + exp(-2*asinh(z/sqrt(x**2 + y**2))))**2*(x**2 + y**2)*exp(2*asinh(z/sqrt(x**2 + y**2)))))
E        +    where <function sqrt at 0x7f3a3ec289a0> = sympy.sqrt
E        +    and   Abs(t**2 - 0.25*(1 + exp(-2*asinh(z/sqrt(x**2 + y**2))))**2*(x**2 + y**2)*exp(2*asinh(z/sqrt(x**2 + y**2)))) = Abs(((t ** 2) - (((0.25 * ((1 + exp(-2*asinh(z/sqrt(x**2 + y**2)))) ** 2)) * ((x ** 2) + (y ** 2))) * exp(2*asinh(z/sqrt(x**2 + y**2))))))
E        +      where Abs = sympy.Abs
E        +      and   exp(-2*asinh(z/sqrt(x**2 + y**2))) = exp((-2 * asinh(z/sqrt(x**2 + y**2))))
E        +        where exp = sympy.exp
E        +        and   asinh(z/sqrt(x**2 + y**2)) = asinh((z / sqrt(x**2 + y**2)))
E        +          where asinh = sympy.asinh
E        +          and   sqrt(x**2 + y**2) = <function sqrt at 0x7f3a3ec289a0>(((x ** 2) + (y ** 2)))
E        +            where <function sqrt at 0x7f3a3ec289a0> = sympy.sqrt
E        +      and   exp(2*asinh(z/sqrt(x**2 + y**2))) = exp((2 * asinh(z/sqrt(x**2 + y**2))))
E        +        where exp = sympy.exp
E        +        and   asinh(z/sqrt(x**2 + y**2)) = asinh((z / sqrt(x**2 + y**2)))
E        +          where asinh = sympy.asinh
E        +          and   sqrt(x**2 + y**2) = <function sqrt at 0x7f3a3ec289a0>(((x ** 2) + (y ** 2)))
E        +            where <function sqrt at 0x7f3a3ec289a0> = sympy.sqrt

tests/compute/sympy/lorentz/test_tau.py:77: AssertionError
________________________________ test_xy_eta_t _________________________________

    def test_xy_eta_t():
        vec = vector.VectorSympy4D(
            vector.backends.sympy.AzimuthalSympyXY(x, y),
            vector.backends.sympy.LongitudinalSympyEta(
                sympy.asinh(z / sympy.sqrt(x**2 + y**2))
            ),
            vector.backends.sympy.TemporalSympyT(t),
        )
        # TODO: the expression blows up on simplifying?
>       assert vec.tau2 == t**2 - 0.25 * (
            1 + sympy.exp(-2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))
        ) ** 2 * (x**2 + y**2) * sympy.exp(2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))
E       assert t**2 - (0.5 + 0.5*exp(-2*asinh(z/sqrt(x**2 + y**2))))**2*(x**2 + y**2)*exp(2*asinh(z/sqrt(x**2 + y**2))) == ((t ** 2) - (((0.25 * ((1 + exp(-2*asinh(z/sqrt(x**2 + y**2)))) ** 2)) * ((x ** 2) + (y ** 2))) * exp(2*asinh(z/sqrt(x**2 + y**2)))))
E        +  where t**2 - (0.5 + 0.5*exp(-2*asinh(z/sqrt(x**2 + y**2))))**2*(x**2 + y**2)*exp(2*asinh(z/sqrt(x**2 + y**2))) = VectorSympy4D(x=x, y=y, eta=asinh(z/sqrt(x**2 + y**2)), t=t).tau2
E        +  and   exp(-2*asinh(z/sqrt(x**2 + y**2))) = exp((-2 * asinh(z/sqrt(x**2 + y**2))))
E        +    where exp = sympy.exp
E        +    and   asinh(z/sqrt(x**2 + y**2)) = asinh((z / sqrt(x**2 + y**2)))
E        +      where asinh = sympy.asinh
E        +      and   sqrt(x**2 + y**2) = <function sqrt at 0x7f3a3ec289a0>(((x ** 2) + (y ** 2)))
E        +        where <function sqrt at 0x7f3a3ec289a0> = sympy.sqrt
E        +  and   exp(2*asinh(z/sqrt(x**2 + y**2))) = exp((2 * asinh(z/sqrt(x**2 + y**2))))
E        +    where exp = sympy.exp
E        +    and   asinh(z/sqrt(x**2 + y**2)) = asinh((z / sqrt(x**2 + y**2)))
E        +      where asinh = sympy.asinh
E        +      and   sqrt(x**2 + y**2) = <function sqrt at 0x7f3a3ec289a0>(((x ** 2) + (y ** 2)))
E        +        where <function sqrt at 0x7f3a3ec289a0> = sympy.sqrt

tests/compute/sympy/lorentz/test_tau2.py:77: AssertionError
_______________________________ test_xy_eta_tau ________________________________

    def test_xy_eta_tau():
        vec = vector.VectorSympy4D(
            azimuthal=vector.backends.sympy.AzimuthalSympyXY(x, y),
            longitudinal=vector.backends.sympy.LongitudinalSympyEta(
                sympy.asinh(z / sympy.sqrt(x**2 + y**2))
            ),
            temporal=vector.backends.sympy.TemporalSympyTau(
                sympy.sqrt(sympy.Abs(-(t**2) + x**2 + y**2 + z**2))
            ),
        )
        out = vec.to_beta3()
        assert isinstance(out, vector.backends.sympy.VectorSympy3D)
        assert type(vec.azimuthal) == type(out.azimuthal)  # noqa: E721
        assert type(vec.longitudinal) == type(out.longitudinal)  # noqa: E721
>       assert out.x == x / sympy.sqrt(
            0.25
            * (1 + sympy.exp(-2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))) ** 2
            * (x**2 + y**2)
            * sympy.exp(2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))
            + sympy.Abs(-(t**2) + x**2 + y**2 + z**2)
        )
E       assert x/sqrt((0.5 + 0.5*exp(-2*asinh(z/sqrt(x**2 + y**2))))**2*(x**2 + y**2)*exp(2*asinh(z/sqrt(x**2 + y**2))) + Abs(-t**2 + x**2 + y**2 + z**2)) == (x / sqrt(0.25*(1 + exp(-2*asinh(z/sqrt(x**2 + y**2))))**2*(x**2 + y**2)*exp(2*asinh(z/sqrt(x**2 + y**2))) + Abs(-t**2 + x**2 + y**2 + z**2)))
E        +  where x/sqrt((0.5 + 0.5*exp(-2*asinh(z/sqrt(x**2 + y**2))))**2*(x**2 + y**2)*exp(2*asinh(z/sqrt(x**2 + y**2))) + Abs(-t**2 + x**2 + y**2 + z**2)) = VectorSympy3D(x=x/sqrt((0.5 + 0.5*exp(-2*asinh(z/sqrt(x**2 + y**2))))**2*(x**2 + y**2)*exp(2*asinh(z/sqrt(x**2 + y**2)...**2*(x**2 + y**2)*exp(2*asinh(z/sqrt(x**2 + y**2))) + Abs(-t**2 + x**2 + y**2 + z**2)), eta=asinh(z/sqrt(x**2 + y**2))).x
E        +  and   sqrt(0.25*(1 + exp(-2*asinh(z/sqrt(x**2 + y**2))))**2*(x**2 + y**2)*exp(2*asinh(z/sqrt(x**2 + y**2))) + Abs(-t**2 + x**2 + y**2 + z**2)) = <function sqrt at 0x7f3a3ec289a0>(((((0.25 * ((1 + exp(-2*asinh(z/sqrt(x**2 + y**2)))) ** 2)) * ((x ** 2) + (y ** 2))) * exp(2*asinh(z/sqrt(x**2 + y**2)))) + Abs(-t**2 + x**2 + y**2 + z**2)))
E        +    where <function sqrt at 0x7f3a3ec289a0> = sympy.sqrt
E        +    and   exp(-2*asinh(z/sqrt(x**2 + y**2))) = exp((-2 * asinh(z/sqrt(x**2 + y**2))))
E        +      where exp = sympy.exp
E        +      and   asinh(z/sqrt(x**2 + y**2)) = asinh((z / sqrt(x**2 + y**2)))
E        +        where asinh = sympy.asinh
E        +        and   sqrt(x**2 + y**2) = <function sqrt at 0x7f3a3ec289a0>(((x ** 2) + (y ** 2)))
E        +          where <function sqrt at 0x7f3a3ec289a0> = sympy.sqrt
E        +    and   exp(2*asinh(z/sqrt(x**2 + y**2))) = exp((2 * asinh(z/sqrt(x**2 + y**2))))
E        +      where exp = sympy.exp
E        +      and   asinh(z/sqrt(x**2 + y**2)) = asinh((z / sqrt(x**2 + y**2)))
E        +        where asinh = sympy.asinh
E        +        and   sqrt(x**2 + y**2) = <function sqrt at 0x7f3a3ec289a0>(((x ** 2) + (y ** 2)))
E        +          where <function sqrt at 0x7f3a3ec289a0> = sympy.sqrt
E        +    and   Abs(-t**2 + x**2 + y**2 + z**2) = Abs((((-(t ** 2) + (x ** 2)) + (y ** 2)) + (z ** 2)))
E        +      where Abs = sympy.Abs

tests/compute/sympy/lorentz/test_to_beta3.py:149: AssertionError
_____________________________ test_rhophi_eta_tau ______________________________

    def test_rhophi_eta_tau():
        vec = vector.VectorSympy4D(
            azimuthal=vector.backends.sympy.AzimuthalSympyRhoPhi(rho, phi),
            longitudinal=vector.backends.sympy.LongitudinalSympyEta(
                sympy.asinh(z / sympy.sqrt(x**2 + y**2))
            ),
            temporal=vector.backends.sympy.TemporalSympyTau(
                sympy.sqrt(sympy.Abs(-(t**2) + x**2 + y**2 + z**2))
            ),
        )
        out = vec.to_beta3()
        assert isinstance(out, vector.backends.sympy.VectorSympy3D)
        assert type(vec.azimuthal) == type(out.azimuthal)  # noqa: E721
        assert type(vec.longitudinal) == type(out.longitudinal)  # noqa: E721
>       assert out.x == rho * sympy.cos(phi) / sympy.sqrt(
            0.25
            * rho**2
            * (1 + sympy.exp(-2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))) ** 2
            * sympy.exp(2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))
            + sympy.Abs(-(t**2) + x**2 + y**2 + z**2)
        )
E       assert rho*cos(phi)/sqrt(rho**2*(0.5 + 0.5*exp(-2*asinh(z/sqrt(x**2 + y**2))))**2*exp(2*asinh(z/sqrt(x**2 + y**2))) + Abs(-t**2 + x**2 + y**2 + z**2)) == ((rho * cos(phi)) / sqrt(0.25*rho**2*(1 + exp(-2*asinh(z/sqrt(x**2 + y**2))))**2*exp(2*asinh(z/sqrt(x**2 + y**2))) + Abs(-t**2 + x**2 + y**2 + z**2)))
E        +  where rho*cos(phi)/sqrt(rho**2*(0.5 + 0.5*exp(-2*asinh(z/sqrt(x**2 + y**2))))**2*exp(2*asinh(z/sqrt(x**2 + y**2))) + Abs(-t**2 + x**2 + y**2 + z**2)) = VectorSympy3D(rho=rho/sqrt(rho**2*(0.5 + 0.5*exp(-2*asinh(z/sqrt(x**2 + y**2))))**2*exp(2*asinh(z/sqrt(x**2 + y**2))) + Abs(-t**2 + x**2 + y**2 + z**2)), phi=phi, eta=asinh(z/sqrt(x**2 + y**2))).x
E        +  and   cos(phi) = cos(phi)
E        +    where cos = sympy.cos
E        +  and   sqrt(0.25*rho**2*(1 + exp(-2*asinh(z/sqrt(x**2 + y**2))))**2*exp(2*asinh(z/sqrt(x**2 + y**2))) + Abs(-t**2 + x**2 + y**2 + z**2)) = <function sqrt at 0x7f3a3ec289a0>(((((0.25 * (rho ** 2)) * ((1 + exp(-2*asinh(z/sqrt(x**2 + y**2)))) ** 2)) * exp(2*asinh(z/sqrt(x**2 + y**2)))) + Abs(-t**2 + x**2 + y**2 + z**2)))
E        +    where <function sqrt at 0x7f3a3ec289a0> = sympy.sqrt
E        +    and   exp(-2*asinh(z/sqrt(x**2 + y**2))) = exp((-2 * asinh(z/sqrt(x**2 + y**2))))
E        +      where exp = sympy.exp
E        +      and   asinh(z/sqrt(x**2 + y**2)) = asinh((z / sqrt(x**2 + y**2)))
E        +        where asinh = sympy.asinh
E        +        and   sqrt(x**2 + y**2) = <function sqrt at 0x7f3a3ec289a0>(((x ** 2) + (y ** 2)))
E        +          where <function sqrt at 0x7f3a3ec289a0> = sympy.sqrt
E        +    and   exp(2*asinh(z/sqrt(x**2 + y**2))) = exp((2 * asinh(z/sqrt(x**2 + y**2))))
E        +      where exp = sympy.exp
E        +      and   asinh(z/sqrt(x**2 + y**2)) = asinh((z / sqrt(x**2 + y**2)))
E        +        where asinh = sympy.asinh
E        +        and   sqrt(x**2 + y**2) = <function sqrt at 0x7f3a3ec289a0>(((x ** 2) + (y ** 2)))
E        +          where <function sqrt at 0x7f3a3ec289a0> = sympy.sqrt
E        +    and   Abs(-t**2 + x**2 + y**2 + z**2) = Abs((((-(t ** 2) + (x ** 2)) + (y ** 2)) + (z ** 2)))
E        +      where Abs = sympy.Abs

tests/compute/sympy/lorentz/test_to_beta3.py:[316](https://github.com/scikit-hep/vector/actions/runs/14703378893/job/41257579268#step:7:317): AssertionError
```

</details>

<details>
  <summary>Failure messages local runs</summary>


```
========================================================= FAILURES =========================================================
_____________________________________________________ test_xy_eta_tau ______________________________________________________

    def test_xy_eta_tau():
        vec = vector.VectorSympy4D(
            azimuthal=vector.backends.sympy.AzimuthalSympyXY(x, y),
            longitudinal=vector.backends.sympy.LongitudinalSympyEta(
                sympy.asinh(z / sympy.sqrt(x**2 + y**2))
            ),
            temporal=vector.backends.sympy.TemporalSympyTau(
                sympy.sqrt(sympy.Abs(-(t**2) + x**2 + y**2 + z**2))
            ),
        )
        out = vec.to_beta3()
        assert isinstance(out, vector.backends.sympy.VectorSympy3D)
        assert type(vec.azimuthal) == type(out.azimuthal)  # noqa: E721
        assert type(vec.longitudinal) == type(out.longitudinal)  # noqa: E721
        expected = x / sympy.sqrt(
            0.25
            * (1 + sympy.exp(-2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))) ** 2
            * (x**2 + y**2)
            * sympy.exp(2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))
            + sympy.Abs(-(t**2) + x**2 + y**2 + z**2)
        )
        assert sympy.simplify(out.x -expected) == 0
>       assert out.y == y / sympy.sqrt(
            0.25
            * (1 + sympy.exp(-2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))) ** 2
            * (x**2 + y**2)
            * sympy.exp(2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))
            + sympy.Abs(-(t**2) + x**2 + y**2 + z**2)
        )
E       assert y/sqrt((0.5 + 0.5*exp(-2*asinh(z/sqrt(x**2 + y**2))))**2*(x**2 + y**2)*exp(2*asinh(z/sqrt(x**2 + y**2))) + Abs(-t**2 + x**2 + y**2 + z**2)) == (y / sqrt(0.25*(1 + exp(-2*asinh(z/sqrt(x**2 + y**2))))**2*(x**2 + y**2)*exp(2*asinh(z/sqrt(x**2 + y**2))) + Abs(-t**2 + x**2 + y**2 + z**2)))
E        +  where y/sqrt((0.5 + 0.5*exp(-2*asinh(z/sqrt(x**2 + y**2))))**2*(x**2 + y**2)*exp(2*asinh(z/sqrt(x**2 + y**2))) + Abs(-t**2 + x**2 + y**2 + z**2)) = VectorSympy3D(x=x/sqrt((0.5 + 0.5*exp(-2*asinh(z/sqrt(x**2 + y**2))))**2*(x**2 + y**2)*exp(2*asinh(z/sqrt(x**2 + y**2)...**2*(x**2 + y**2)*exp(2*asinh(z/sqrt(x**2 + y**2))) + Abs(-t**2 + x**2 + y**2 + z**2)), eta=asinh(z/sqrt(x**2 + y**2))).y
E        +  and   sqrt(0.25*(1 + exp(-2*asinh(z/sqrt(x**2 + y**2))))**2*(x**2 + y**2)*exp(2*asinh(z/sqrt(x**2 + y**2))) + Abs(-t**2 + x**2 + y**2 + z**2)) = <function sqrt at 0x1083f0540>(((((0.25 * ((1 + exp(-2*asinh(z/sqrt(x**2 + y**2)))) ** 2)) * ((x ** 2) + (y ** 2))) * exp(2*asinh(z/sqrt(x**2 + y**2)))) + Abs(-t**2 + x**2 + y**2 + z**2)))
E        +    where <function sqrt at 0x1083f0540> = sympy.sqrt
E        +    and   exp(-2*asinh(z/sqrt(x**2 + y**2))) = exp((-2 * asinh(z/sqrt(x**2 + y**2))))
E        +      where exp = sympy.exp
E        +      and   asinh(z/sqrt(x**2 + y**2)) = asinh((z / sqrt(x**2 + y**2)))
E        +        where asinh = sympy.asinh
E        +        and   sqrt(x**2 + y**2) = <function sqrt at 0x1083f0540>(((x ** 2) + (y ** 2)))
E        +          where <function sqrt at 0x1083f0540> = sympy.sqrt
E        +    and   exp(2*asinh(z/sqrt(x**2 + y**2))) = exp((2 * asinh(z/sqrt(x**2 + y**2))))
E        +      where exp = sympy.exp
E        +      and   asinh(z/sqrt(x**2 + y**2)) = asinh((z / sqrt(x**2 + y**2)))
E        +        where asinh = sympy.asinh
E        +        and   sqrt(x**2 + y**2) = <function sqrt at 0x1083f0540>(((x ** 2) + (y ** 2)))
E        +          where <function sqrt at 0x1083f0540> = sympy.sqrt
E        +    and   Abs(-t**2 + x**2 + y**2 + z**2) = Abs((((-(t ** 2) + (x ** 2)) + (y ** 2)) + (z ** 2)))
E        +      where Abs = sympy.Abs

tests/compute/sympy/lorentz/test_to_beta3.py:157: AssertionError
___________________________________________________ test_rhophi_eta_tau ____________________________________________________

    def test_rhophi_eta_tau():
        vec = vector.VectorSympy4D(
            azimuthal=vector.backends.sympy.AzimuthalSympyRhoPhi(rho, phi),
            longitudinal=vector.backends.sympy.LongitudinalSympyEta(
                sympy.asinh(z / sympy.sqrt(x**2 + y**2))
            ),
            temporal=vector.backends.sympy.TemporalSympyTau(
                sympy.sqrt(sympy.Abs(-(t**2) + x**2 + y**2 + z**2))
            ),
        )
        out = vec.to_beta3()
        assert isinstance(out, vector.backends.sympy.VectorSympy3D)
        assert type(vec.azimuthal) == type(out.azimuthal)  # noqa: E721
        assert type(vec.longitudinal) == type(out.longitudinal)  # noqa: E721
        expected = rho * sympy.cos(phi) / sympy.sqrt(
            0.25
            * rho**2
            * (1 + sympy.exp(-2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))) ** 2
            * sympy.exp(2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))
            + sympy.Abs(-(t**2) + x**2 + y**2 + z**2)
        )
        assert sympy.simplify(out.x-expected) == 0
>       assert out.y == rho * sympy.sin(phi) / sympy.sqrt(
            0.25
            * rho**2
            * (1 + sympy.exp(-2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))) ** 2
            * sympy.exp(2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))
            + sympy.Abs(-(t**2) + x**2 + y**2 + z**2)
        )
E       assert rho*sin(phi)/sqrt(rho**2*(0.5 + 0.5*exp(-2*asinh(z/sqrt(x**2 + y**2))))**2*exp(2*asinh(z/sqrt(x**2 + y**2))) + Abs(-t**2 + x**2 + y**2 + z**2)) == ((rho * sin(phi)) / sqrt(0.25*rho**2*(1 + exp(-2*asinh(z/sqrt(x**2 + y**2))))**2*exp(2*asinh(z/sqrt(x**2 + y**2))) + Abs(-t**2 + x**2 + y**2 + z**2)))
E        +  where rho*sin(phi)/sqrt(rho**2*(0.5 + 0.5*exp(-2*asinh(z/sqrt(x**2 + y**2))))**2*exp(2*asinh(z/sqrt(x**2 + y**2))) + Abs(-t**2 + x**2 + y**2 + z**2)) = VectorSympy3D(rho=rho/sqrt(rho**2*(0.5 + 0.5*exp(-2*asinh(z/sqrt(x**2 + y**2))))**2*exp(2*asinh(z/sqrt(x**2 + y**2))) + Abs(-t**2 + x**2 + y**2 + z**2)), phi=phi, eta=asinh(z/sqrt(x**2 + y**2))).y
E        +  and   sin(phi) = sin(phi)
E        +    where sin = sympy.sin
E        +  and   sqrt(0.25*rho**2*(1 + exp(-2*asinh(z/sqrt(x**2 + y**2))))**2*exp(2*asinh(z/sqrt(x**2 + y**2))) + Abs(-t**2 + x**2 + y**2 + z**2)) = <function sqrt at 0x1083f0540>(((((0.25 * (rho ** 2)) * ((1 + exp(-2*asinh(z/sqrt(x**2 + y**2)))) ** 2)) * exp(2*asinh(z/sqrt(x**2 + y**2)))) + Abs(-t**2 + x**2 + y**2 + z**2)))
E        +    where <function sqrt at 0x1083f0540> = sympy.sqrt
E        +    and   exp(-2*asinh(z/sqrt(x**2 + y**2))) = exp((-2 * asinh(z/sqrt(x**2 + y**2))))
E        +      where exp = sympy.exp
E        +      and   asinh(z/sqrt(x**2 + y**2)) = asinh((z / sqrt(x**2 + y**2)))
E        +        where asinh = sympy.asinh
E        +        and   sqrt(x**2 + y**2) = <function sqrt at 0x1083f0540>(((x ** 2) + (y ** 2)))
E        +          where <function sqrt at 0x1083f0540> = sympy.sqrt
E        +    and   exp(2*asinh(z/sqrt(x**2 + y**2))) = exp((2 * asinh(z/sqrt(x**2 + y**2))))
E        +      where exp = sympy.exp
E        +      and   asinh(z/sqrt(x**2 + y**2)) = asinh((z / sqrt(x**2 + y**2)))
E        +        where asinh = sympy.asinh
E        +        and   sqrt(x**2 + y**2) = <function sqrt at 0x1083f0540>(((x ** 2) + (y ** 2)))
E        +          where <function sqrt at 0x1083f0540> = sympy.sqrt
E        +    and   Abs(-t**2 + x**2 + y**2 + z**2) = Abs((((-(t ** 2) + (x ** 2)) + (y ** 2)) + (z ** 2)))
E        +      where Abs = sympy.Abs

tests/compute/sympy/lorentz/test_to_beta3.py:325: AssertionError
```
</details>

## Checklist

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't any other open Pull Requests for the required change?
- [x] Does your submission pass pre-commit? (`$ pre-commit run --all-files` or `$ nox -s lint`)
- [x] Does your submission pass tests? (`$ pytest` or `$ nox -s tests`)
- [x] Does the documentation build with your changes? (`$ cd docs; make clean; make html` or `$ nox -s docs`)
- [x] Does your submission pass the doctests? (`$ pytest --doctest-plus src/vector/` or `$ nox -s doctests`)

## Before Merging

- [ ] Summarize the commit messages into a brief review of the Pull request.
