### PR TITLE
Upper pin 3.14 for numba

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ optional-dependencies.dev = [
   "dask-awkward",
   "sympy",
   "nox",
-  "numba>=0.57",
+  "numba>=0.57; python_version<'3.14'",
   "papermill>=2.4",
   "pytest>=6",
   "pytest-cov>=3",
@@ -73,7 +73,7 @@ optional-dependencies.docs = [
   "sphinx-math-dollar",
 ]
 optional-dependencies.numba = [
-  "numba>=0.57",
+  "numba>=0.57; python_version<'3.14'",
 ]
 optional-dependencies.sympy = [
   "sympy",


### PR DESCRIPTION
## Description

Merged the last PR accidentally. I should have upper pinned python to 3.14 as numba releases are always (justifiably) late.