### PR TITLE
fix: drop python 3.8; it's EOL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"
@@ -65,7 +64,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -207,7 +207,6 @@ nox -s tests        # test with all extra dependencies on all available Python v
 nox -s tests        # run doctests on all available Python versions
 nox -s coverage     # run the tests session and generate a coverage report on all available Python versions
 nox -s notebooks    # test notebooks on the default Python version
-nox -s disassemble  # check compute functions on Python 3.9
 ```
 
 ### Building documentation with nox

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -207,7 +207,7 @@ nox -s tests        # test with all extra dependencies on all available Python v
 nox -s tests        # run doctests on all available Python versions
 nox -s coverage     # run the tests session and generate a coverage report on all available Python versions
 nox -s notebooks    # test notebooks on the default Python version
-nox -s disassemble  # check compute functions on Python 3.8
+nox -s disassemble  # check compute functions on Python 3.9
 ```
 
 ### Building documentation with nox

--- a/noxfile.py
+++ b/noxfile.py
@@ -8,7 +8,7 @@ nox.options.sessions = ["lint", "lite", "tests", "doctests", "disassemble"]
 nox.needs_version = ">=2024.4.15"
 nox.options.default_venv_backend = "uv|virtualenv"
 
-ALL_PYTHON = ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+ALL_PYTHON = ["3.9", "3.10", "3.11", "3.12", "3.13"]
 DIR = Path(__file__).parent.resolve()
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ maintainers = [
 authors = [
   { name = "Jim Pivarski, Henry Schreiner, Eduardo Rodrigues", email = "eduardo.rodrigues@cern.ch" },
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
@@ -27,7 +27,6 @@ classifiers = [
   "Operating System :: OS Independent",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
@@ -164,7 +163,7 @@ isort.required-imports = [
 ]
 
 [tool.pylint]
-master.py-version = "3.8"
+master.py-version = "3.9"
 reports.output-format = "colorized"
 similarities.ignore-imports = "yes"
 master.jobs = "0"
@@ -253,7 +252,7 @@ filterwarnings = [
 files = [
   "src/vector",
 ]
-python_version = "3.8"
+python_version = "3.9"
 strict = true
 warn_return_any = false
 enable_error_code = [


### PR DESCRIPTION
Dropping python 3.8, it's EOL.
