### PR TITLE
docs: fix edit button link

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -85,6 +85,7 @@ html_theme_options = {
     "use_repository_button": True,
     "use_issues_button": True,
     "use_edit_page_button": True,
+    "path_to_docs": "docs/",
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,


### PR DESCRIPTION
## Description

The edit button right now does not work as our docs (like any typical python package) are not in the root directory but in the `docs` subdirectory.

## Checklist

- [X] Have you followed the guidelines in our Contributing document?
- [X] Have you checked to ensure there aren't any other open Pull Requests for the required change?
- [X] Does your submission pass pre-commit? (`$ pre-commit run --all-files` or `$ nox -s lint`)
- [X] Does your submission pass tests? (`$ pytest` or `$ nox -s tests`)
- [X] Does the documentation build with your changes? (`$ cd docs; make clean; make html` or `$ nox -s docs`)
- [X] Does your submission pass the doctests? (`$ pytest --doctest-plus src/vector/` or `$ nox -s doctests`)

## Before Merging

- [ ] Summarize the commit messages into a brief review of the Pull request.
