### PR TITLE
chore: update some things in pyproject.toml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - pip >=18
   - pytest >=6
   - numba >=0.57
-  - numpy >=1.13.3
+  - numpy >=1.19.3
   - root >=6.18.04
   - pip:
       - "awkward>=2.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ readme = { file = "README.md", content-type = "text/markdown" }
 keywords = [
   "vector",
 ]
+license = "BSD-3-Clause"
 maintainers = [
   { name = "The Scikit-HEP admins", email = "scikit-hep-admins@googlegroups.com" },
 ]
@@ -23,7 +24,6 @@ classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
   "Intended Audience :: Science/Research",
-  "License :: OSI Approved :: BSD License",
   "Operating System :: OS Independent",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
@@ -32,6 +32,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Topic :: Scientific/Engineering",
   "Topic :: Scientific/Engineering :: Information Analysis",
   "Topic :: Scientific/Engineering :: Mathematics",
@@ -42,8 +43,8 @@ dynamic = [
   "version",
 ]
 dependencies = [
-  "numpy>=1.13.3",
-  "packaging>=19",
+  "numpy>=1.19.3",
+  "packaging>=20",
 ]
 
 [project.optional-dependencies]
@@ -126,7 +127,6 @@ extend-select = [
 ignore = [
   "PLR09",   # Too many X
   "PLR2004", # Magic values
-  "ISC001", # Conflicts with formatter
 ]
 typing-modules = [
   "vector._typeutils",


### PR DESCRIPTION
This updates a few things in the pyproject.toml. Mostly updating the numpy version to the oldest version that actually supported Python 3.9, and packaging to something that was released the same year as 3.9, but also using SPDX license, and a few other updates. The 3.14 classifier was missing, too.
