### PR TITLE
fix: get rid of cupy<14 quick fix

### DIFF
--- a/src/vector/_compute/spatial/eta.py
+++ b/src/vector/_compute/spatial/eta.py
@@ -13,7 +13,7 @@
 from __future__ import annotations
 
 import typing
-from math import inf
+from math import inf, nan
 
 import numpy
 
@@ -30,16 +30,12 @@ from vector._methods import (
 )
 
 
-# TODO: https://github.com/scikit-hep/vector/issues/615
-# revert back to `nan_to_num` implementation once
-# https://github.com/cupy/cupy/issues/9143 is fixed.
-# `lib.where` works but there is no SymPy equivalent for the function.
 def xy_z(lib, x, y, z):
-    return (
-        lib.where(
-            z != 0, lib.arcsinh(lib.where(z != 0, z / lib.sqrt(x**2 + y**2), z)), z
-        )
-        * 1
+    return lib.nan_to_num(
+        lib.arcsinh(z / lib.sqrt(x**2 + y**2)),
+        nan=lib.nan_to_num((z != 0) * inf, posinf=nan),
+        posinf=inf,
+        neginf=-inf,
     )
 
 
@@ -56,12 +52,13 @@ def xy_eta(lib, x, y, eta):
 xy_eta.__awkward_transform_allowed__ = False  # type:ignore[attr-defined]
 
 
-# TODO: https://github.com/scikit-hep/vector/issues/615
-# revert back to `nan_to_num` implementation once
-# https://github.com/cupy/cupy/issues/9143 is fixed.
-# `lib.where` works but there is no SymPy equivalent for the function.
 def rhophi_z(lib, rho, phi, z):
-    return lib.where(z != 0, lib.arcsinh(lib.where(z != 0, z / rho, z)), z) * 1
+    return lib.nan_to_num(
+        lib.arcsinh(z / rho),
+        nan=lib.nan_to_num((z != 0) * inf, posinf=nan),
+        posinf=inf,
+        neginf=-inf,
+    )
 
 
 def rhophi_theta(lib, rho, phi, theta):

--- a/src/vector/backends/sympy.py
+++ b/src/vector/backends/sympy.py
@@ -43,17 +43,6 @@ class _lib:
     """a wrapper that maps numpy functions to sympy functions (or custom implementations)"""
 
     # functions modified specifically for sympy
-
-    # TODO: https://github.com/scikit-hep/vector/issues/615
-    # should NOT be used as a replacement for np.where as it works specifically for the
-    # case of vector/_compute/spatial/eta.py. `where` returns the second argument and
-    # ignores the third (first argument is a boolean condition) because the purpose of
-    # this function is to handle exceptional values — we know that the "normal" values
-    # are in the second argument and the "exceptional" ones are in the third argument.
-    # remove once https://github.com/cupy/cupy/issues/9143 is fixed.
-    def where(self, val1: sympy.Expr, val2: sympy.Expr, val3: sympy.Expr) -> sympy.Expr:
-        return val2
-
     def nan_to_num(self, val: sympy.Expr, **kwargs: typing.Any) -> sympy.Expr:
         return val
 


### PR DESCRIPTION
## Description

Fixes #615

The weird CuPy behavior was fixed in v14 by @ikrommyd (thanks!).

## Checklist

- [X] Have you followed the guidelines in our Contributing document?
- [X] Have you checked to ensure there aren't any other open Pull Requests for the required change?
- [X] Does your submission pass pre-commit? (`$ pre-commit run --all-files` or `$ nox -s lint`)
- [X] Does your submission pass tests? (`$ pytest` or `$ nox -s tests`)
- [X] Does the documentation build with your changes? (`$ cd docs; make clean; make html` or `$ nox -s docs`)
- [X] Does your submission pass the doctests? (`$ pytest --doctest-plus src/vector/` or `$ nox -s doctests`)

## Before Merging

- [ ] Summarize the commit messages into a brief review of the Pull request.
