### PR TITLE
ci: enable numba testing in 3.14t

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -80,9 +80,7 @@ def doctests(session: nox.Session) -> None:
 @nox.session(reuse_venv=True, default=False)
 def notebooks(session: nox.Session) -> None:
     """Run the notebook tests"""
-    test_deps = nox.project.dependency_groups(
-        PYPROJECT, "test", "test-optional", "test-numba"
-    )
+    test_deps = nox.project.dependency_groups(PYPROJECT, "test", "test-optional")
     session.install("-e.", *test_deps)
     session.install("jupyter")
     session.run("pytest", "tests/test_notebooks.py", *session.posargs)

--- a/noxfile.py
+++ b/noxfile.py
@@ -52,9 +52,7 @@ def tests(session: nox.Session) -> None:
         sysconfig.get_config_var("Py_GIL_DISABLED")
     ):
         os.environ["PYTHON_GIL"] = "0"
-        test_deps = nox.project.dependency_groups(PYPROJECT, "test-all-no-gil")
-    else:
-        test_deps = nox.project.dependency_groups(PYPROJECT, "test-all-gil")
+    test_deps = nox.project.dependency_groups(PYPROJECT, "test-all")
     session.install("-e.", *test_deps)
     session.run(
         "pytest",
@@ -74,7 +72,7 @@ def coverage(session: nox.Session) -> None:
 @nox.session(reuse_venv=True, python=ALL_PYTHON)
 def doctests(session: nox.Session) -> None:
     """Run the doctests."""
-    test_deps = nox.project.dependency_groups(PYPROJECT, "test-all-gil")
+    test_deps = nox.project.dependency_groups(PYPROJECT, "test-all")
     session.install("-e.", *test_deps)
     session.run("pytest", "--doctest-plus", "src/vector/", *session.posargs)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,14 +96,11 @@ docs = [
   "hepunits",
   "matplotlib",
 ]
-test-all-no-gil = [
+test-all = [
   { include-group = "test"},
   { include-group = "test-optional"},
-  { include-group = "test-extras"},
-]
-test-all-gil = [
-  { include-group = "test-all-no-gil"},
   { include-group = "test-numba"},
+  { include-group = "test-extras"},
 ]
 dev = [
   { include-group = "test"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,8 +99,8 @@ docs = [
 test-all = [
   { include-group = "test"},
   { include-group = "test-optional"},
-  { include-group = "test-numba"},
   { include-group = "test-extras"},
+  { include-group = "test-numba"},
 ]
 dev = [
   { include-group = "test"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,10 +72,8 @@ test = [
 ]
 test-optional = [
   "awkward>=2",
-  "sympy",
-]
-test-numba = [
   "numba>=0.57; python_version<'3.15'",
+  "sympy",
 ]
 test-extras = [
   "jax",
@@ -100,12 +98,10 @@ test-all = [
   { include-group = "test"},
   { include-group = "test-optional"},
   { include-group = "test-extras"},
-  { include-group = "test-numba"},
 ]
 dev = [
   { include-group = "test"},
   { include-group = "test-optional"},
-  { include-group = "test-numba"},
 ]
 
 [tool.hatch]

--- a/tests/backends/test_numba_object.py
+++ b/tests/backends/test_numba_object.py
@@ -68,7 +68,10 @@ def test_VectorObjectType():
                 vector.backends.object.VectorObject2D
             )
         else:
-            assert class_refs == sys.getrefcount(vector.backends.object.VectorObject2D)
+            assert (
+                abs(class_refs - sys.getrefcount(vector.backends.object.VectorObject2D))
+                <= 1
+            )
 
     class_refs = None
     for _ in range(10):
@@ -90,7 +93,10 @@ def test_VectorObjectType():
                 vector.backends.object.VectorObject2D
             )
         else:
-            assert class_refs == sys.getrefcount(vector.backends.object.VectorObject2D)
+            assert (
+                abs(class_refs - sys.getrefcount(vector.backends.object.VectorObject2D))
+                <= 1
+            )
 
     class_refs = None
     for _ in range(10):
@@ -122,7 +128,10 @@ def test_VectorObjectType():
                 vector.backends.object.VectorObject2D
             )
         else:
-            assert class_refs == sys.getrefcount(vector.backends.object.VectorObject2D)
+            assert (
+                abs(class_refs - sys.getrefcount(vector.backends.object.VectorObject2D))
+                <= 1
+            )
 
     # These tests just check that the rest of the implementations are sane.
 


### PR DESCRIPTION
Numba now has 3.14t wheels. We should enable testing.
Partially reverts the dependency split done in https://github.com/scikit-hep/vector/pull/676 for the exact reason that numba did not have wheels at the time.