### PR TITLE
restricting dynamic attribute assignment for object backend using `__slots__`

### DIFF
--- a/src/vector/_methods.py
+++ b/src/vector/_methods.py
@@ -22,10 +22,12 @@ Module = typing.Any  # returns a module, but we can't be specific about which on
 
 
 class Coordinates:
-    pass
+    __slots__ = ()
 
 
 class Azimuthal(Coordinates):
+    __slots__ = ()
+
     @property
     def elements(self) -> tuple[ScalarCollection, ScalarCollection]:
         """
@@ -38,6 +40,8 @@ class Azimuthal(Coordinates):
 
 
 class Longitudinal(Coordinates):
+    __slots__ = ()
+
     @property
     def elements(self) -> tuple[ScalarCollection]:
         """
@@ -50,6 +54,8 @@ class Longitudinal(Coordinates):
 
 
 class Temporal(Coordinates):
+    __slots__ = ()
+
     @property
     def elements(self) -> tuple[ScalarCollection]:
         """
@@ -68,6 +74,7 @@ class AzimuthalXY(Azimuthal):
         y (scalar, ``np.ndarray``, ``ak.Array``, etc.): The $y$ coordinate(s).
     """
 
+    __slots__ = ()
     x: ScalarCollection
     y: ScalarCollection
 
@@ -79,6 +86,7 @@ class AzimuthalRhoPhi(Azimuthal):
         phi (scalar, ``np.ndarray``, ``ak.Array``, etc.): The $\phi$ coordinate(s).
     """
 
+    __slots__ = ()
     rho: ScalarCollection
     phi: ScalarCollection
 
@@ -89,6 +97,7 @@ class LongitudinalZ(Longitudinal):
         z (scalar, ``np.ndarray``, ``ak.Array``, etc.): The $z$ coordinate(s).
     """
 
+    __slots__ = ()
     z: ScalarCollection
 
 
@@ -98,6 +107,7 @@ class LongitudinalTheta(Longitudinal):
         theta (scalar, ``np.ndarray``, ``ak.Array``, etc.): The $\theta$ coordinate(s).
     """
 
+    __slots__ = ()
     theta: ScalarCollection
 
 
@@ -107,6 +117,7 @@ class LongitudinalEta(Longitudinal):
         eta (scalar, ``np.ndarray``, ``ak.Array``, etc.): The $\eta$ coordinate(s).
     """
 
+    __slots__ = ()
     eta: ScalarCollection
 
 
@@ -116,6 +127,7 @@ class TemporalT(Temporal):
         t (scalar, ``np.ndarray``, ``ak.Array``, etc.): The $t$ coordinate(s).
     """
 
+    __slots__ = ()
     t: ScalarCollection
 
 
@@ -125,6 +137,7 @@ class TemporalTau(Temporal):
         tau (scalar, ``np.ndarray``, ``ak.Array``, etc.): The $\tau$ coordinate(s).
     """
 
+    __slots__ = ()
     tau: ScalarCollection
 
 
@@ -147,6 +160,8 @@ class VectorProtocol:
         MomentumClass (type): The momentum class for this type, for vectors with
             momentum-synonyms.
     """
+
+    __slots__ = ()
 
     @property
     def lib(self) -> Module: ...
@@ -710,6 +725,8 @@ class VectorProtocol:
 
 
 class VectorProtocolPlanar(VectorProtocol):
+    __slots__ = ()
+
     @property
     def azimuthal(self) -> Azimuthal:
         """
@@ -833,6 +850,8 @@ class VectorProtocolPlanar(VectorProtocol):
 
 
 class VectorProtocolSpatial(VectorProtocolPlanar):
+    __slots__ = ()
+
     @property
     def longitudinal(self) -> Longitudinal:
         """
@@ -1087,6 +1106,8 @@ class VectorProtocolSpatial(VectorProtocolPlanar):
 
 
 class VectorProtocolLorentz(VectorProtocolSpatial):
+    __slots__ = ()
+
     @property
     def temporal(self) -> Temporal:
         """
@@ -1458,6 +1479,8 @@ class VectorProtocolLorentz(VectorProtocolSpatial):
 
 
 class MomentumProtocolPlanar(VectorProtocolPlanar):
+    __slots__ = ()
+
     @property
     def px(self) -> ScalarCollection:
         """Momentum-synonym for :attr:`vector._methods.VectorProtocolPlanar.x`."""
@@ -1480,6 +1503,8 @@ class MomentumProtocolPlanar(VectorProtocolPlanar):
 
 
 class MomentumProtocolSpatial(VectorProtocolSpatial, MomentumProtocolPlanar):
+    __slots__ = ()
+
     @property
     def pz(self) -> ScalarCollection:
         """Momentum-synonym for :attr:`vector._methods.VectorProtocolSpatial.z`."""
@@ -1502,6 +1527,8 @@ class MomentumProtocolSpatial(VectorProtocolSpatial, MomentumProtocolPlanar):
 
 
 class MomentumProtocolLorentz(VectorProtocolLorentz, MomentumProtocolSpatial):
+    __slots__ = ()
+
     @property
     def E(self) -> ScalarCollection:
         """Momentum-synonyor :attr:`vector._methods.VectorProtocolLorentz.t`."""
@@ -1648,6 +1675,8 @@ class MomentumProtocolLorentz(VectorProtocolLorentz, MomentumProtocolSpatial):
 
 
 class Vector(VectorProtocol):
+    __slots__ = ()
+
     @typing.overload
     def __new__(cls, *, x: float, y: float) -> vector.VectorObject2D: ...
 
@@ -3170,6 +3199,8 @@ class Vector(VectorProtocol):
 
 
 class Vector2D(Vector, VectorProtocolPlanar):
+    __slots__ = ()
+
     def to_Vector2D(self) -> VectorProtocolPlanar:
         return self
 
@@ -3306,6 +3337,8 @@ class Vector2D(Vector, VectorProtocolPlanar):
 
 
 class Vector3D(Vector, VectorProtocolSpatial):
+    __slots__ = ()
+
     def to_Vector2D(self) -> VectorProtocolPlanar:
         return self._wrap_result(
             type(self),
@@ -3384,6 +3417,8 @@ class Vector3D(Vector, VectorProtocolSpatial):
 
 
 class Vector4D(Vector, VectorProtocolLorentz):
+    __slots__ = ()
+
     def to_Vector2D(self) -> VectorProtocolPlanar:
         return self._wrap_result(
             type(self),
@@ -3423,6 +3458,8 @@ class Vector4D(Vector, VectorProtocolLorentz):
 
 
 class Planar(VectorProtocolPlanar):
+    __slots__ = ()
+
     @property
     def x(self) -> ScalarCollection:
         from vector._compute.planar import x
@@ -3554,6 +3591,8 @@ class Planar(VectorProtocolPlanar):
 
 
 class Spatial(Planar, VectorProtocolSpatial):
+    __slots__ = ()
+
     @property
     def z(self) -> ScalarCollection:
         from vector._compute.spatial import z
@@ -3794,6 +3833,8 @@ class Spatial(Planar, VectorProtocolSpatial):
 
 
 class Lorentz(Spatial, VectorProtocolLorentz):
+    __slots__ = ()
+
     @property
     def t(self) -> ScalarCollection:
         from vector._compute.lorentz import t
@@ -4065,10 +4106,12 @@ class Lorentz(Spatial, VectorProtocolLorentz):
 
 
 class Momentum:
-    pass
+    __slots__ = ()
 
 
 class PlanarMomentum(Momentum, MomentumProtocolPlanar):
+    __slots__ = ()
+
     @property
     def px(self) -> ScalarCollection:
         return self.x
@@ -4087,6 +4130,8 @@ class PlanarMomentum(Momentum, MomentumProtocolPlanar):
 
 
 class SpatialMomentum(PlanarMomentum, MomentumProtocolSpatial):
+    __slots__ = ()
+
     @property
     def pz(self) -> ScalarCollection:
         return self.z
@@ -4105,6 +4150,8 @@ class SpatialMomentum(PlanarMomentum, MomentumProtocolSpatial):
 
 
 class LorentzMomentum(SpatialMomentum, MomentumProtocolLorentz):
+    __slots__ = ()
+
     @property
     def E(self) -> ScalarCollection:
         return self.t

--- a/src/vector/backends/object.py
+++ b/src/vector/backends/object.py
@@ -71,17 +71,25 @@ from vector._typeutils import FloatArray
 class CoordinatesObject:
     """Coordinates class for the Object backend."""
 
+    __slots__ = ()
+
 
 class AzimuthalObject(CoordinatesObject, Azimuthal):
     """Azimuthal class for the Object backend."""
+
+    __slots__ = ()
 
 
 class LongitudinalObject(CoordinatesObject, Longitudinal):
     """Longitudinal class for the Object backend."""
 
+    __slots__ = ()
+
 
 class TemporalObject(CoordinatesObject, Temporal):
     """Temporal class for the Object backend."""
+
+    __slots__ = ()
 
 
 class TupleXY(typing.NamedTuple):
@@ -96,6 +104,8 @@ class AzimuthalObjectXY(AzimuthalObject, AzimuthalXY, TupleXY):
     Class for the ``x`` and ``y`` (azimuthal) coordinates of Object backend.
     Use the ``elements`` property to retrieve the coordinates.
     """
+
+    __slots__ = ()
 
     @property
     def elements(self) -> tuple[float, float]:
@@ -126,6 +136,8 @@ class AzimuthalObjectRhoPhi(AzimuthalObject, AzimuthalRhoPhi, TupleRhoPhi):
     Use the ``elements`` property to retrieve the coordinates.
     """
 
+    __slots__ = ()
+
     @property
     def elements(self) -> tuple[float, float]:
         """
@@ -153,6 +165,8 @@ class LongitudinalObjectZ(LongitudinalObject, LongitudinalZ, TupleZ):
     Class for the ``z`` (longitudinal) coordinate of Object backend.
     Use the ``elements`` property to retrieve the coordinates.
     """
+
+    __slots__ = ()
 
     @property
     def elements(self) -> tuple[float]:
@@ -182,6 +196,8 @@ class LongitudinalObjectTheta(LongitudinalObject, LongitudinalTheta, TupleTheta)
     Use the ``elements`` property to retrieve the coordinates.
     """
 
+    __slots__ = ()
+
     @property
     def elements(self) -> tuple[float]:
         """
@@ -209,6 +225,8 @@ class LongitudinalObjectEta(LongitudinalObject, LongitudinalEta, TupleEta):
     Class for the ``eta`` (longitudinal) coordinate of Object backend.
     Use the ``elements`` property to retrieve the coordinates.
     """
+
+    __slots__ = ()
 
     @property
     def elements(self) -> tuple[float]:
@@ -238,6 +256,8 @@ class TemporalObjectT(TemporalObject, TemporalT, TupleT):
     Use the ``elements`` property to retrieve the coordinates.
     """
 
+    __slots__ = ()
+
     @property
     def elements(self) -> tuple[float]:
         """
@@ -265,6 +285,8 @@ class TemporalObjectTau(TemporalObject, TemporalTau, TupleTau):
     Class for the ``tau`` (temporal) coordinate of Object backend.
     Use the ``elements`` property to retrieve the coordinates.
     """
+
+    __slots__ = ()
 
     @property
     def elements(self) -> tuple[float]:
@@ -329,6 +351,7 @@ def _replace_data(obj: typing.Any, result: typing.Any) -> typing.Any:
 class VectorObject(Vector):  # noqa: PLW1641
     """Mixin class for Object vectors."""
 
+    __slots__ = ()
     lib = numpy
 
     # The type ignore comments below cannot be removed because `VectorObject`


### PR DESCRIPTION
## Description

**Kindly take a look at [CONTRIBUTING.md](https://github.com/scikit-hep/vector/blob/main/.github/CONTRIBUTING.md).**

_Please describe the purpose of this pull request. Reference and link to any relevant issues or pull requests._

I was experimenting with the Vector library and saw that we can assign `z` to a VectorObject2D object and it neither throws an error nor does it automatically change it to a `VectorObject3D`:

```python
import vector
vec=vector.obj(x=1, y=2)
vec.z=8    # no error
print(type(vec))    
# output: <class 'vector.backends.object.VectorObject2D'>
vec.blah_blah=78    # no error
```

I saw there were some conversations about adding `__slots__` [here](https://github.com/scikit-hep/vector/pull/163#issuecomment-1006741092).. so i started working on this.

The `VectorObject2/3/4D` classes already had `__slots__` correctly defined but they were not being used because their parent classes had no `__slots__` defined so the default `__dict__` was still getting created (refer https://docs.python.org/3/reference/datamodel.html#slots )-- so it was allowing adding any attribute to a VectorObject2D object, like `vec.blah_blah=78`.

In this PR I added `__slots__ = ()` to parent classes and now the above code raises an error:

```python
>>> import vector
>>> vec=vector.obj(x=1, y=2)
>>> vec.z=8
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'VectorObject2D' object has no attribute 'z'
```

But, because the classes in `_methods.py` are also being used by the Awkward arrays backend-- so there were some test failures ([test logs under this PR](https://github.com/scikit-hep/vector/actions/runs/25008098921/job/73236374099?pr=700))

<details>
  <summary>error summary</summary>

```
======================================================================================== short test summary info =========================================================================================
FAILED tests/backends/test_awkward.py::test_dimension_conversion[cpu] - TypeError: __class__ assignment: 'MomentumArray2D' object layout differs from 'Array'
FAILED tests/backends/test_awkward.py::test_dimension_conversion[typetracer] - TypeError: __class__ assignment: 'MomentumArray2D' object layout differs from 'Array'
FAILED tests/backends/test_awkward.py::test_basic[cpu] - TypeError: __class__ assignment: 'MomentumArray2D' object layout differs from 'Array'
FAILED tests/backends/test_awkward.py::test_basic[typetracer] - TypeError: __class__ assignment: 'MomentumArray2D' object layout differs from 'Array'
FAILED tests/backends/test_awkward.py::test_rotateZ[cpu] - TypeError: __class__ assignment: 'MomentumArray2D' object layout differs from 'Array'
FAILED tests/backends/test_awkward.py::test_rotateZ[typetracer] - TypeError: __class__ assignment: 'MomentumArray2D' object layout differs from 'Array'
FAILED tests/backends/test_awkward.py::test_like[cpu] - TypeError: __class__ assignment: 'MomentumArray2D' object layout differs from 'Array'
FAILED tests/backends/test_awkward.py::test_like[typetracer] - TypeError: __class__ assignment: 'MomentumArray2D' object layout differs from 'Array'
FAILED tests/backends/test_awkward.py::test_momentum_coordinate_transforms[cpu] - TypeError: __class__ assignment: 'MomentumArray2D' object layout differs from 'Array'
FAILED tests/backends/test_awkward.py::test_momentum_coordinate_transforms[typetracer] - TypeError: __class__ assignment: 'MomentumArray2D' object layout differs from 'Array'
FAILED tests/backends/test_awkward.py::test_momentum_preservation[cpu] - TypeError: __class__ assignment: 'MomentumArray2D' object layout differs from 'Array'
FAILED tests/backends/test_awkward.py::test_momentum_preservation[typetracer] - TypeError: __class__ assignment: 'MomentumArray2D' object layout differs from 'Array'
FAILED tests/backends/test_awkward.py::test_subclass_fields[cpu] - TypeError: __class__ assignment: 'LorentzVectorArray' object layout differs from 'Array'
FAILED tests/backends/test_awkward.py::test_subclass_fields[typetracer] - TypeError: __class__ assignment: 'LorentzVectorArray' object layout differs from 'Array'
FAILED tests/backends/test_awkward_numba.py::test - TypeError: __class__ assignment: 'MomentumArray4D' object layout differs from 'Array'
FAILED tests/backends/test_dask_awkward.py::test_necessary_columns - TypeError: __class__ assignment: 'MomentumArray2D' object layout differs from 'Array'
FAILED tests/test_issues.py::test_issue_161 - TypeError: __class__ assignment: 'MomentumArray4D' object layout differs from 'Array'
FAILED tests/test_issues.py::test_issue_443 - TypeError: __class__ assignment: 'MomentumArray4D' object layout differs from 'Array'
FAILED tests/test_issues.py::test_issue_621 - TypeError: __class__ assignment: 'MomentumArray4D' object layout differs from 'Array'
FAILED tests/test_notebooks.py::test_awkward - papermill.exceptions.PapermillExecutionError: 
FAILED tests/test_notebooks.py::test_numba - papermill.exceptions.PapermillExecutionError: 
=============================================================================== 21 failed, 805 passed in 107.23s (0:01:47) ===============================================================================
```

</details>

Right now, I'm not very familiar with how the awkward arrays are integrated within Vector. I would appreciate any guidance on what's the best way to make this work without bothering the Awkward arrays backend (@henryiii  @jpivarski ). Pls LMK if that's even possible without creating separate `_methods.py`s for every backend, if not then feel free to close this PR.

Thank you!

<br>

PS: one work-around I tried was to put `ak.Array` first in the class definition for classes `MomentumArray2/3/4D` i.e. `class MomentumArray4D(ak.Array, MomentumAwkward4D):` instead of `class MomentumArray4D(MomentumAwkward4D, ak.Array):`. Although it made some tests pass, I don't think it's a good solution bcoz it might break some user code, as it would give `ak.Array`'s methods priority over `MomentumAwkward2/3/4D`'s methods when there will be any conflicts; and the `test_subclass_fields` was still failing.

<details>
  <summary>error logs</summary>

```
____________________________________________________________________________________ test_subclass_fields[typetracer] ____________________________________________________________________________________

backend = 'typetracer'

    @pytest.mark.parametrize("backend", ["cpu", "typetracer"])
    def test_subclass_fields(backend):
        @ak.mixin_class(vector.backends.awkward.behavior)
        class TwoVector(vector.backends.awkward.MomentumAwkward2D):
            pass
    
        @ak.mixin_class(vector.backends.awkward.behavior)
        class ThreeVector(vector.backends.awkward.MomentumAwkward3D):
            pass
    
        @ak.mixin_class(vector.backends.awkward.behavior)
        class LorentzVector(vector.backends.awkward.MomentumAwkward4D):
            @ak.mixin_class_method(np.divide, {numbers.Number})
            def divide(self, factor):
                return self.scale(1 / factor)
    
        LorentzVectorArray.ProjectionClass2D = TwoVectorArray  # noqa: F821
        LorentzVectorArray.ProjectionClass3D = ThreeVectorArray  # noqa: F821
        LorentzVectorArray.ProjectionClass4D = LorentzVectorArray  # noqa: F821
        LorentzVectorArray.MomentumClass = LorentzVectorArray  # noqa: F821
    
        vec = ak.to_backend(
>           ak.zip(
                {
                    "pt": [[1, 2], [], [3], [4]],
                    "eta": [[1.2, 1.4], [], [1.6], [3.4]],
                    "phi": [[0.3, 0.4], [], [0.5], [0.6]],
                    "energy": [[50, 51], [], [52], [60]],
                },
                with_name="LorentzVector",
                behavior=vector.backends.awkward.behavior,
            ),
            backend=backend,
        )

tests/backends/test_awkward.py:1157: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
../../.pyenv/versions/3.12.13/lib/python3.12/site-packages/awkward/_dispatch.py:41: in dispatch
    with OperationErrorContext(name, args, kwargs):
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
../../.pyenv/versions/3.12.13/lib/python3.12/site-packages/awkward/_errors.py:80: in __exit__
    raise self.decorate_exception(exception_type, exception_value)
../../.pyenv/versions/3.12.13/lib/python3.12/site-packages/awkward/_dispatch.py:67: in dispatch
    next(gen_or_result)
../../.pyenv/versions/3.12.13/lib/python3.12/site-packages/awkward/operations/ak_zip.py:153: in zip
    return _impl(
../../.pyenv/versions/3.12.13/lib/python3.12/site-packages/awkward/operations/ak_zip.py:265: in _impl
    wrapped_out = ctx.wrap(out, highlevel=highlevel)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
../../.pyenv/versions/3.12.13/lib/python3.12/site-packages/awkward/_layout.py:181: in wrap
    return wrap_layout(
../../.pyenv/versions/3.12.13/lib/python3.12/site-packages/awkward/_layout.py:234: in wrap_layout
    return awkward.highlevel.Array(content, behavior=behavior, attrs=attrs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
../../.pyenv/versions/3.12.13/lib/python3.12/site-packages/awkward/highlevel.py:365: in __init__
    self._update_class()
../../.pyenv/versions/3.12.13/lib/python3.12/site-packages/awkward/highlevel.py:382: in _update_class
    self.__class__ = get_array_class(self._layout, self._behavior)
    ^^^^^^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <[TypeError("__class__ assignment: 'LorentzVectorArray' object layout differs from 'Array'") raised in repr()] Array object at 0x10e7e1940>, name = '__class__'
value = <class 'tests.backends.test_awkward.LorentzVectorArray'>

    def __setattr__(self, name, value):
        """
        Args:
            where (str): Attribute name to set
    
        Set an attribute on the array.
    
        Only existing public attributes e.g. #ak.Array.layout, or private
        attributes (with leading underscores), can be set.
    
        Fields are not assignable to as attributes, i.e. the following doesn't work:
    
            array.z = new_field
    
        Instead, always use #ak.Array.__setitem__:
    
            array["z"] = new_field
    
        or #ak.with_field:
    
            array = ak.with_field(array, new_field, "z")
    
        to add or modify a field.
        """
        if name.startswith("_") or hasattr(type(self), name):
>           super().__setattr__(name, value)
E           TypeError: __class__ assignment: 'LorentzVectorArray' object layout differs from 'Array'
E           
E           This error occurred while calling
E           
E               ak.zip(
E                   {'pt': [[1, 2], [], [3], [4]], 'eta': [[1.2, 1.4], [], [1.6], [3.4]],...
E                   with_name = 'LorentzVector'
E                   behavior = {('*', 'Vector2D'): <class 'vector.backends.awkward.Vector...
E               )

../../.pyenv/versions/3.12.13/lib/python3.12/site-packages/awkward/highlevel.py:1327: TypeError

======================================================================================== short test summary info =========================================================================================
FAILED tests/backends/test_awkward.py::test_subclass_fields[cpu] - TypeError: __class__ assignment: 'LorentzVectorArray' object layout differs from 'Array'
FAILED tests/backends/test_awkward.py::test_subclass_fields[typetracer] - TypeError: __class__ assignment: 'LorentzVectorArray' object layout differs from 'Array'
FAILED tests/test_notebooks.py::test_awkward - papermill.exceptions.PapermillExecutionError: 
FAILED tests/test_notebooks.py::test_numba - papermill.exceptions.PapermillExecutionError: 
================================================================================ 4 failed, 822 passed in 97.58s (0:01:37) ================================================================================

```
</details>

## Checklist

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't any other open Pull Requests for the required change?
- [x] Does your submission pass pre-commit? (`$ pre-commit run --all-files` or `$ nox -s lint`)
- [ ] Does your submission pass tests? (`$ pytest` or `$ nox -s tests`)
- [x] Does the documentation build with your changes? (`$ cd docs; make clean; make html` or `$ nox -s docs`)
- [x] Does your submission pass the doctests? (`$ pytest --doctest-plus src/vector/` or `$ nox -s doctests`)

## Before Merging

- [ ] Summarize the commit messages into a brief review of the Pull request.
