### PR TITLE
fix: _wrap_results skips momentum equivalents

### DIFF
--- a/src/vector/backends/awkward.py
+++ b/src/vector/backends/awkward.py
@@ -720,7 +720,9 @@ class VectorAwkward:
                         names.append(name)
                         arrays.append(self[name])
 
-            if any(f in fields for f in ("t", "tau", "M", "m", "mass", "E", "e", "energy")):
+            if any(
+                f in fields for f in ("t", "tau", "M", "m", "mass", "E", "e", "energy")
+            ):
                 cls = cls.ProjectionClass4D
             elif any(f in fields for f in ("z", "pz", "theta", "eta")):
                 cls = cls.ProjectionClass3D
@@ -839,7 +841,9 @@ class VectorAwkward:
                         names.append(name)
                         arrays.append(self[name])
 
-            if any(f in fields for f in ("t", "tau", "M", "m", "mass", "E", "e", "energy")):
+            if any(
+                f in fields for f in ("t", "tau", "M", "m", "mass", "E", "e", "energy")
+            ):
                 cls = cls.ProjectionClass4D
             else:
                 cls = cls.ProjectionClass3D

--- a/src/vector/backends/awkward.py
+++ b/src/vector/backends/awkward.py
@@ -720,9 +720,9 @@ class VectorAwkward:
                         names.append(name)
                         arrays.append(self[name])
 
-            if "t" in fields or "tau" in fields:
+            if any(f in fields for f in ("t", "tau", "M", "m", "mass", "E", "e", "energy")):
                 cls = cls.ProjectionClass4D
-            elif "z" in fields or "theta" in fields or "eta" in fields:
+            elif any(f in fields for f in ("z", "pz", "theta", "eta")):
                 cls = cls.ProjectionClass3D
             else:
                 cls = cls.ProjectionClass2D
@@ -839,7 +839,7 @@ class VectorAwkward:
                         names.append(name)
                         arrays.append(self[name])
 
-            if "t" in fields or "tau" in fields:
+            if any(f in fields for f in ("t", "tau", "M", "m", "mass", "E", "e", "energy")):
                 cls = cls.ProjectionClass4D
             else:
                 cls = cls.ProjectionClass3D

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -289,8 +289,23 @@ def test_issue_704():
     ak = pytest.importorskip("awkward")
     vector.register_awkward()
 
-    vec_ak = ak.zip({"pt": [1, 2, 3, 4], "eta": [1, 2, 3, 4], "phi": [1, 2, 3, 4], "mass": [1, 2, 3, 4]}, with_name="Momentum4D")
-    vec_vec = vector.zip({"pt": [1, 2, 3, 4], "eta": [1, 2, 3, 4], "phi": [1, 2, 3, 4], "mass": [1, 2, 3, 4]})
+    vec_ak = ak.zip(
+        {
+            "pt": [1, 2, 3, 4],
+            "eta": [1, 2, 3, 4],
+            "phi": [1, 2, 3, 4],
+            "mass": [1, 2, 3, 4],
+        },
+        with_name="Momentum4D",
+    )
+    vec_vec = vector.zip(
+        {
+            "pt": [1, 2, 3, 4],
+            "eta": [1, 2, 3, 4],
+            "phi": [1, 2, 3, 4],
+            "mass": [1, 2, 3, 4],
+        }
+    )
 
     assert isinstance(vec_ak.neg3D, vector.backends.awkward.MomentumArray4D)
     assert isinstance(vec_vec.neg3D, vector.backends.awkward.MomentumArray4D)

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -283,3 +283,15 @@ def test_issue_657():
 
             assert transformed_r1.isclose(transformed_r2)
             assert not transformed_r1.isclose(transformed_r2, rtol=1e-10, atol=1e-10)
+
+
+def test_issue_704():
+    ak = pytest.importorskip("awkward")
+    vector.register_awkward()
+
+    vec_ak = ak.zip({"pt": [1, 2, 3, 4], "eta": [1, 2, 3, 4], "phi": [1, 2, 3, 4], "mass": [1, 2, 3, 4]}, with_name="Momentum4D")
+    vec_vec = vector.zip({"pt": [1, 2, 3, 4], "eta": [1, 2, 3, 4], "phi": [1, 2, 3, 4], "mass": [1, 2, 3, 4]})
+
+    assert isinstance(vec_ak.neg3D, vector.backends.awkward.MomentumArray4D)
+    assert isinstance(vec_vec.neg3D, vector.backends.awkward.MomentumArray4D)
+    assert all(vec_ak.neg3D == vec_vec.neg3D)


### PR DESCRIPTION
## Description

Fixes #704

More generally, `_wrap_results` skipped momentum coordinates at some places. Vector internally converts coordinates so everything works (and worked), but using an Awkward Array with Vector behaviors did not work (as there is no `t` or `tau` in fields, but there is `m` for instance).

## Checklist

- [X] Have you followed the guidelines in our Contributing document?
- [X] Have you checked to ensure there aren't any other open Pull Requests for the required change?
- [X] Does your submission pass pre-commit? (`$ pre-commit run --all-files` or `$ nox -s lint`)
- [X] Does your submission pass tests? (`$ pytest` or `$ nox -s tests`)
- [X] Does the documentation build with your changes? (`$ cd docs; make clean; make html` or `$ nox -s docs`)
- [X] Does your submission pass the doctests? (`$ pytest --doctest-plus src/vector/` or `$ nox -s doctests`)

## Before Merging

- [ ] Summarize the commit messages into a brief review of the Pull request.
