### PR TITLE
chore: fix noxfile, CI pass gate, and stale config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,9 +99,11 @@ jobs:
 
   pass:
     needs: [pre-commit, check-lite, check-full]
+    if: always()
     runs-on: ubuntu-latest
     steps:
-      - run: echo "All jobs passed"
+      - name: Decide whether all required jobs succeeded
+        run: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
 
   # root:
   #   runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,6 @@ repos:
       - id: end-of-file-fixer
         exclude: ^docs
       - id: mixed-line-ending
-      - id: requirements-txt-fixer
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
@@ -54,7 +53,7 @@ repos:
     hooks:
       - id: blacken-docs
         args: ["-E"]
-        additional_dependencies: [black~=24.0]
+        additional_dependencies: [black~=25.0]
 
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.10.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,7 +53,7 @@ repos:
     hooks:
       - id: blacken-docs
         args: ["-E"]
-        additional_dependencies: [black~=25.0]
+        additional_dependencies: [black~=26.0]
 
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.10.0

--- a/noxfile.py
+++ b/noxfile.py
@@ -6,9 +6,6 @@
 
 from __future__ import annotations
 
-import os
-import sys
-import sysconfig
 from pathlib import Path
 
 import nox
@@ -40,18 +37,24 @@ def pylint(session: nox.Session) -> None:
 @nox.session(reuse_venv=True, python=ALL_PYTHON)
 def lite(session: nox.Session) -> None:
     """Run lightweight tests."""
+    is_free_threaded = isinstance(session.python, str) and session.python.endswith("t")
+    run_env = {"PYTHON_GIL": "0"} if is_free_threaded else {}
     test_deps = nox.project.dependency_groups(PYPROJECT, "test")
     session.install("-e.", *test_deps)
-    session.run("pytest", "--ignore", "tests/test_notebooks.py", *session.posargs)
+    session.run(
+        "pytest",
+        "--ignore",
+        "tests/test_notebooks.py",
+        *session.posargs,
+        env=run_env,
+    )
 
 
 @nox.session(reuse_venv=True, python=ALL_PYTHON)
 def tests(session: nox.Session) -> None:
     """Run the unit and regular tests."""
-    if sys.version_info[:2] >= (3, 14) and bool(
-        sysconfig.get_config_var("Py_GIL_DISABLED")
-    ):
-        os.environ["PYTHON_GIL"] = "0"
+    is_free_threaded = isinstance(session.python, str) and session.python.endswith("t")
+    run_env = {"PYTHON_GIL": "0"} if is_free_threaded else {}
     test_deps = nox.project.dependency_groups(PYPROJECT, "test-all")
     session.install("-e.", *test_deps)
     session.run(
@@ -59,6 +62,7 @@ def tests(session: nox.Session) -> None:
         "--ignore",
         "tests/test_notebooks.py",
         *session.posargs,
+        env=run_env,
     )
 
 
@@ -90,7 +94,7 @@ def notebooks(session: nox.Session) -> None:
 def docs(session: nox.Session) -> None:
     """Build the docs. Pass "serve" to serve."""
     doc_deps = nox.project.dependency_groups(PYPROJECT, "docs", "test")
-    session.install("-e.", doc_deps)
+    session.install("-e.", *doc_deps)
     session.chdir("docs")
     session.run("sphinx-build", "-M", "html", ".", "_build")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ test = [
 ]
 test-optional = [
   "awkward>=2",
-  "numba>=0.57; python_version<'3.15'",
+  "numba>=0.62; python_version<'3.15'",
   "sympy",
 ]
 test-extras = [
@@ -226,7 +226,6 @@ messages_control.disable = [
   "unused-import",
   "pointless-string-statement",
   "useless-option-value",
-  "cast_python_value",
   "unknown-option-value",
   "no-else-raise",
   "unidiomatic-typecheck",


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

- **noxfile `docs` session**: `session.install("-e.", doc_deps)` was passing the deps list as a single argument (TypeError at runtime). Fixed to `session.install("-e.", *doc_deps)`.
- **noxfile free-threaded env**: Was inspecting `sys.version_info`/`sysconfig` of the nox host interpreter and mutating `os.environ["PYTHON_GIL"]`, leaking into subsequent sessions. Now detects free-threaded builds from the `"t"` suffix on `session.python` and passes `env={"PYTHON_GIL": "0"}` to `session.run(...)` only. Applied to both `lite` and `tests` sessions (CI runs `lite` on 3.14t). Drops unused `os`/`sys`/`sysconfig` imports.
- **CI `pass` gate**: Added `if: always()` and a step that fails when any upstream job is in `failure` or `cancelled` state, so skipped jobs no longer satisfy branch protection.
- **numba lower bound**: Aligned `test-optional` group from `>=0.57` to `>=0.62` to match the published `[numba]` extra.
- **Duplicate pylint disable**: Removed the second `"cast_python_value"` entry from `pyproject.toml`.
- **Dead `requirements-txt-fixer` hook**: Removed from `.pre-commit-config.yaml` (no `requirements*.txt` files exist in the repo).
- **`blacken-docs` black pin**: Bumped `additional_dependencies: [black~=24.0]` → `black~=25.0`; pre-commit.ci autoupdate never touches `additional_dependencies`.

Part of #711

All changes validated: `yaml.safe_load` on CI YAML OK, `uvx nox -l` lists sessions without error, `prek -a --quiet` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)