### PR TITLE
fix: not_equal, is_perpendicular, and is_spacelike predicate logic

### DIFF
--- a/src/vector/_compute/lorentz/is_spacelike.py
+++ b/src/vector/_compute/lorentz/is_spacelike.py
@@ -63,7 +63,7 @@ def make_function(azimuthal, longitudinal, temporal):
     def f(lib, tolerance, coord1, coord2, coord3, coord4):
         return dot_function(
             lib, coord1, coord2, coord3, coord4, coord1, coord2, coord3, coord4
-        ) < lib.absolute(tolerance)
+        ) < -lib.absolute(tolerance)
 
     dispatch_map[azimuthal, longitudinal, temporal] = (f, bool)
 

--- a/src/vector/_compute/lorentz/not_equal.py
+++ b/src/vector/_compute/lorentz/not_equal.py
@@ -17,7 +17,7 @@ import typing
 import numpy
 
 from vector._compute.lorentz import t
-from vector._compute.spatial import equal
+from vector._compute.spatial import not_equal
 from vector._methods import (
     Azimuthal,
     AzimuthalRhoPhi,
@@ -71,7 +71,7 @@ dispatch_map: dict[
 def make_conversion(
     azimuthal1, longitudinal1, temporal1, azimuthal2, longitudinal2, temporal2
 ):
-    spatial_equal, _ = equal.dispatch_map[
+    spatial_not_equal, _ = not_equal.dispatch_map[
         azimuthal1, longitudinal1, azimuthal2, longitudinal2
     ]
 
@@ -146,7 +146,7 @@ def make_conversion(
         def f(
             lib, coord11, coord12, coord13, coord14, coord21, coord22, coord23, coord24
         ):
-            return (coord14 != coord24) & spatial_equal(
+            return (coord14 != coord24) | spatial_not_equal(
                 lib, coord11, coord12, coord13, coord21, coord22, coord23
             )
 
@@ -158,7 +158,9 @@ def make_conversion(
             return (
                 to_t1(lib, coord11, coord12, coord13, coord14)
                 != to_t2(lib, coord21, coord22, coord23, coord24)
-            ) & spatial_equal(lib, coord11, coord12, coord13, coord21, coord22, coord23)
+            ) | spatial_not_equal(
+                lib, coord11, coord12, coord13, coord21, coord22, coord23
+            )
 
     dispatch_map[
         azimuthal1, longitudinal1, temporal1, azimuthal2, longitudinal2, temporal2

--- a/src/vector/_compute/planar/is_perpendicular.py
+++ b/src/vector/_compute/planar/is_perpendicular.py
@@ -54,9 +54,11 @@ def make_function(azimuthal1, azimuthal2):
     rho2_function, _ = rho.dispatch_map[azimuthal2,]
 
     def f(lib, tolerance, coord11, coord12, coord21, coord22):
-        return dot_function(lib, coord11, coord12, coord21, coord22) < lib.absolute(
-            tolerance
-        ) * rho1_function(lib, coord11, coord12) * rho2_function(lib, coord21, coord22)
+        return lib.absolute(
+            dot_function(lib, coord11, coord12, coord21, coord22)
+        ) < lib.absolute(tolerance) * rho1_function(
+            lib, coord11, coord12
+        ) * rho2_function(lib, coord21, coord22)
 
     dispatch_map[azimuthal1, azimuthal2] = (f, bool)
 

--- a/src/vector/_compute/planar/not_equal.py
+++ b/src/vector/_compute/planar/not_equal.py
@@ -32,7 +32,7 @@ from vector._methods import (
 
 # same types
 def xy_xy(lib, x1, y1, x2, y2):
-    return (x1 != x2) & (y1 != y2)
+    return (x1 != x2) | (y1 != y2)
 
 
 def xy_rhophi(lib, x1, y1, rho2, phi2):
@@ -45,7 +45,7 @@ def rhophi_xy(lib, rho1, phi1, x2, y2):
 
 # same types
 def rhophi_rhophi(lib, rho1, phi1, rho2, phi2):
-    return (rho1 != rho2) & (phi1 != phi2)
+    return (rho1 != rho2) | (phi1 != phi2)
 
 
 dispatch_map = {

--- a/src/vector/_compute/spatial/is_perpendicular.py
+++ b/src/vector/_compute/spatial/is_perpendicular.py
@@ -63,8 +63,8 @@ def make_function(azimuthal1, longitudinal1, azimuthal2, longitudinal2):
     mag2_function, _ = mag.dispatch_map[azimuthal2, longitudinal2]
 
     def f(lib, tolerance, coord11, coord12, coord13, coord21, coord22, coord23):
-        return dot_function(
-            lib, coord11, coord12, coord13, coord21, coord22, coord23
+        return lib.absolute(
+            dot_function(lib, coord11, coord12, coord13, coord21, coord22, coord23)
         ) < lib.absolute(tolerance) * mag1_function(
             lib, coord11, coord12, coord13
         ) * mag2_function(lib, coord21, coord22, coord23)

--- a/src/vector/_compute/spatial/not_equal.py
+++ b/src/vector/_compute/spatial/not_equal.py
@@ -38,7 +38,7 @@ from vector._methods import (
 
 # same types
 def xy_z_xy_z(lib, x1, y1, z1, x2, y2, z2):
-    return (x1 != x2) & (y1 != y2) & (z1 != z2)
+    return (x1 != x2) | (y1 != y2) | (z1 != z2)
 
 
 def xy_z_xy_theta(lib, x1, y1, z1, x2, y2, theta2):
@@ -85,7 +85,7 @@ def xy_theta_xy_z(lib, x1, y1, theta1, x2, y2, z2):
 
 # same types
 def xy_theta_xy_theta(lib, x1, y1, theta1, x2, y2, theta2):
-    return (x1 != x2) & (y1 != y2) & (theta1 != theta2)
+    return (x1 != x2) | (y1 != y2) | (theta1 != theta2)
 
 
 def xy_theta_xy_eta(lib, x1, y1, theta1, x2, y2, eta2):
@@ -138,7 +138,7 @@ def xy_eta_xy_theta(lib, x1, y1, eta1, x2, y2, theta2):
 
 # same types
 def xy_eta_xy_eta(lib, x1, y1, eta1, x2, y2, eta2):
-    return (x1 != x2) & (y1 != y2) & (eta1 != eta2)
+    return (x1 != x2) | (y1 != y2) | (eta1 != eta2)
 
 
 def xy_eta_rhophi_z(lib, x1, y1, eta1, rho2, phi2, z2):
@@ -203,7 +203,7 @@ def rhophi_z_xy_eta(lib, rho1, phi1, z1, x2, y2, eta2):
 
 # same types
 def rhophi_z_rhophi_z(lib, rho1, phi1, z1, rho2, phi2, z2):
-    return (rho1 != rho2) & (phi1 != phi2) & (z1 != z2)
+    return (rho1 != rho2) | (phi1 != phi2) | (z1 != z2)
 
 
 def rhophi_z_rhophi_theta(lib, rho1, phi1, z1, rho2, phi2, theta2):
@@ -262,7 +262,7 @@ def rhophi_theta_rhophi_z(lib, rho1, phi1, theta1, rho2, phi2, z2):
 
 # same types
 def rhophi_theta_rhophi_theta(lib, rho1, phi1, theta1, rho2, phi2, theta2):
-    return (rho1 != rho2) & (phi1 != phi2) & (theta1 != theta2)
+    return (rho1 != rho2) | (phi1 != phi2) | (theta1 != theta2)
 
 
 def rhophi_theta_rhophi_eta(lib, rho1, phi1, theta1, rho2, phi2, eta2):
@@ -315,7 +315,7 @@ def rhophi_eta_rhophi_theta(lib, rho1, phi1, eta1, rho2, phi2, theta2):
 
 # same types
 def rhophi_eta_rhophi_eta(lib, rho1, phi1, eta1, rho2, phi2, eta2):
-    return (rho1 != rho2) & (phi1 != phi2) & (eta1 != eta2)
+    return (rho1 != rho2) | (phi1 != phi2) | (eta1 != eta2)
 
 
 dispatch_map = {

--- a/tests/compute/lorentz/test_is_spacelike.py
+++ b/tests/compute/lorentz/test_is_spacelike.py
@@ -282,3 +282,34 @@ def test_rhophi_eta_tau():
         vector.backends.object.TemporalObjectTau(1.7320508075688772),
     )
     assert not vec.is_spacelike()
+
+
+def test_tolerance_partition():
+    # Regression: with a nonzero tolerance, is_spacelike/is_lightlike/is_timelike
+    # must partition the light cone without overlap. A nearly-lightlike timelike
+    # vector should be lightlike only, never spacelike.
+    vec = vector.backends.object.VectorObject4D(
+        vector.backends.object.AzimuthalObjectXY(1, 0),
+        vector.backends.object.LongitudinalObjectZ(0),
+        vector.backends.object.TemporalObjectT(1.0000001),
+    )
+    assert not vec.is_spacelike(tolerance=1e-3)
+    assert vec.is_lightlike(tolerance=1e-3)
+    assert not vec.is_timelike(tolerance=1e-3)
+
+    # A clearly timelike vector is not spacelike even with a nonzero tolerance.
+    vec = vector.backends.object.VectorObject4D(
+        vector.backends.object.AzimuthalObjectXY(0, 0),
+        vector.backends.object.LongitudinalObjectZ(0),
+        vector.backends.object.TemporalObjectT(2),
+    )
+    assert not vec.is_spacelike(tolerance=1e-3)
+    assert vec.is_timelike(tolerance=1e-3)
+
+    # A clearly spacelike vector remains spacelike with a nonzero tolerance.
+    vec = vector.backends.object.VectorObject4D(
+        vector.backends.object.AzimuthalObjectXY(2, 0),
+        vector.backends.object.LongitudinalObjectZ(0),
+        vector.backends.object.TemporalObjectT(0),
+    )
+    assert vec.is_spacelike(tolerance=1e-3)

--- a/tests/compute/sympy/test_is_perpendicular.py
+++ b/tests/compute/sympy/test_is_perpendicular.py
@@ -30,6 +30,10 @@ def test_planar_sympy():
     assert not v1.is_perpendicular(v3).subs(values)
     assert not v2.is_perpendicular(v3).subs(values)
 
+    # antiparallel vectors are not perpendicular (regression: needs abs(dot))
+    v4 = vector.VectorSympy2D(azimuthal=vector.backends.sympy.AzimuthalSympyXY(-1, 0))
+    assert not v2.is_perpendicular(v4).subs(values)
+
     for t1 in "xy", "rhophi":
         for t2 in "xy", "rhophi":
             tr1, tr2 = (
@@ -58,6 +62,13 @@ def test_spatial_sympy():
     assert v1.is_perpendicular(v2).subs(values)
     assert not v1.is_perpendicular(v3).subs(values)
     assert not v2.is_perpendicular(v3).subs(values)
+
+    # antiparallel vectors are not perpendicular (regression: needs abs(dot))
+    v4 = vector.VectorSympy3D(
+        azimuthal=vector.backends.sympy.AzimuthalSympyXY(-1, 0),
+        longitudinal=vector.backends.sympy.LongitudinalSympyZ(0),
+    )
+    assert not v2.is_perpendicular(v4).subs(values)
 
     for t1 in "xyz", "xytheta", "xyeta", "rhophiz", "rhophitheta", "rhophieta":
         for t2 in "xyz", "xytheta", "xyeta", "rhophiz", "rhophitheta", "rhophieta":

--- a/tests/compute/sympy/test_not_equal.py
+++ b/tests/compute/sympy/test_not_equal.py
@@ -21,6 +21,10 @@ def test_planar_sympy():
     v2 = vector.VectorSympy2D(azimuthal=vector.backends.sympy.AzimuthalSympyXY(x, y))
     assert not v1.not_equal(v2)
 
+    # differ in a single component (regression: not_equal must OR, not AND)
+    v3 = vector.VectorSympy2D(azimuthal=vector.backends.sympy.AzimuthalSympyXY(x, z))
+    assert v1.not_equal(v3)
+
     for t1 in "xy", "rhophi":
         for t2 in "xy", "rhophi":
             transformed1, transformed2 = (

--- a/tests/compute/test_is_perpendicular.py
+++ b/tests/compute/test_is_perpendicular.py
@@ -28,6 +28,12 @@ def test_planar_object():
     assert not v1.is_perpendicular(v3)
     assert not v2.is_perpendicular(v3)
 
+    # antiparallel vectors are not perpendicular (regression: needs abs(dot))
+    v4 = vector.backends.object.VectorObject2D(
+        azimuthal=vector.backends.object.AzimuthalObjectXY(-1, 0)
+    )
+    assert not v2.is_perpendicular(v4)
+
     for t1 in "xy", "rhophi":
         for t2 in "xy", "rhophi":
             tr1, tr2 = (
@@ -56,6 +62,13 @@ def test_planar_numpy():
     assert v1.is_perpendicular(v2)
     assert not v1.is_perpendicular(v3)
     assert not v2.is_perpendicular(v3)
+
+    # antiparallel vectors are not perpendicular (regression: needs abs(dot))
+    v4 = vector.backends.numpy.VectorNumpy2D(
+        [(-1, 0)],
+        dtype=[("x", numpy.float64), ("y", numpy.float64)],
+    )
+    assert not v2.is_perpendicular(v4)
 
     for t1 in "xy", "rhophi":
         for t2 in "xy", "rhophi":
@@ -86,6 +99,13 @@ def test_spatial_object():
     assert not v1.is_perpendicular(v3)
     assert not v2.is_perpendicular(v3)
 
+    # antiparallel vectors are not perpendicular (regression: needs abs(dot))
+    v4 = vector.backends.object.VectorObject3D(
+        azimuthal=vector.backends.object.AzimuthalObjectXY(-1, 0),
+        longitudinal=vector.backends.object.LongitudinalObjectZ(0),
+    )
+    assert not v2.is_perpendicular(v4)
+
     for t1 in "xyz", "xytheta", "xyeta", "rhophiz", "rhophitheta", "rhophieta":
         for t2 in "xyz", "xytheta", "xyeta", "rhophiz", "rhophitheta", "rhophieta":
             tr1, tr2 = (
@@ -114,6 +134,13 @@ def test_spatial_numpy():
     assert v1.is_perpendicular(v2)
     assert not v1.is_perpendicular(v3)
     assert not v2.is_perpendicular(v3)
+
+    # antiparallel vectors are not perpendicular (regression: needs abs(dot))
+    v4 = vector.backends.numpy.VectorNumpy3D(
+        [(-1, 0, 0)],
+        dtype=[("x", numpy.float64), ("y", numpy.float64), ("z", numpy.float64)],
+    )
+    assert not v2.is_perpendicular(v4)
 
     for t1 in "xyz", "xytheta", "xyeta", "rhophiz", "rhophitheta", "rhophieta":
         for t2 in "xyz", "xytheta", "xyeta", "rhophiz", "rhophitheta", "rhophieta":

--- a/tests/compute/test_not_equal.py
+++ b/tests/compute/test_not_equal.py
@@ -20,6 +20,12 @@ def test_planar_object():
     )
     assert not v1.not_equal(v2)
 
+    # differ in a single component (regression: not_equal must OR, not AND)
+    v3 = vector.backends.object.VectorObject2D(
+        azimuthal=vector.backends.object.AzimuthalObjectXY(0.1, 0.3)
+    )
+    assert v1.not_equal(v3)
+
     for t1 in "xy", "rhophi":
         for t2 in "xy", "rhophi":
             transformed1, transformed2 = (
@@ -40,6 +46,13 @@ def test_planar_numpy():
         dtype=[("x", numpy.float64), ("y", numpy.float64)],
     )
     assert not v1.not_equal(v2).all()
+
+    # differ in a single component (regression: not_equal must OR, not AND)
+    v3 = vector.backends.numpy.VectorNumpy2D(
+        [(0.1, 0.3)],
+        dtype=[("x", numpy.float64), ("y", numpy.float64)],
+    )
+    assert v1.not_equal(v3).all()
 
     for t1 in "xy", "rhophi":
         for t2 in "xy", "rhophi":
@@ -62,6 +75,13 @@ def test_spatial_object():
     )
     assert not v1.not_equal(v2)
 
+    # differ in a single component (regression: not_equal must OR, not AND)
+    v3 = vector.backends.object.VectorObject3D(
+        azimuthal=vector.backends.object.AzimuthalObjectXY(0.1, 0.2),
+        longitudinal=vector.backends.object.LongitudinalObjectZ(0.4),
+    )
+    assert v1.not_equal(v3)
+
     for t1 in "xyz", "xytheta", "xyeta", "rhophiz", "rhophitheta", "rhophieta":
         for t2 in "xyz", "xytheta", "xyeta", "rhophiz", "rhophitheta", "rhophieta":
             transformed1, transformed2 = (
@@ -82,6 +102,13 @@ def test_spatial_numpy():
         dtype=[("x", numpy.float64), ("y", numpy.float64), ("z", numpy.float64)],
     )
     assert not v1.not_equal(v2).all()
+
+    # differ in a single component (regression: not_equal must OR, not AND)
+    v3 = vector.backends.numpy.VectorNumpy3D(
+        [(0.1, 0.2, 0.4)],
+        dtype=[("x", numpy.float64), ("y", numpy.float64), ("z", numpy.float64)],
+    )
+    assert v1.not_equal(v3).all()
 
     for t1 in "xyz", "xytheta", "xyeta", "rhophiz", "rhophitheta", "rhophieta":
         for t2 in "xyz", "xytheta", "xyeta", "rhophiz", "rhophitheta", "rhophieta":
@@ -105,6 +132,22 @@ def test_lorentz_object():
         temporal=vector.backends.object.TemporalObjectT(0.4),
     )
     assert not v1.not_equal(v2)
+
+    # differ only in the temporal component (regression: not_equal must OR)
+    v_t = vector.backends.object.VectorObject4D(
+        azimuthal=vector.backends.object.AzimuthalObjectXY(0.1, 0.2),
+        longitudinal=vector.backends.object.LongitudinalObjectZ(0.3),
+        temporal=vector.backends.object.TemporalObjectT(0.5),
+    )
+    assert v1.not_equal(v_t)
+
+    # differ only in a spatial component (regression: not_equal must OR)
+    v_x = vector.backends.object.VectorObject4D(
+        azimuthal=vector.backends.object.AzimuthalObjectXY(0.9, 0.2),
+        longitudinal=vector.backends.object.LongitudinalObjectZ(0.3),
+        temporal=vector.backends.object.TemporalObjectT(0.4),
+    )
+    assert v1.not_equal(v_x)
 
     for t1 in (
         "xyzt",
@@ -159,6 +202,30 @@ def test_lorentz_numpy():
         ],
     )
     assert not v1.not_equal(v2).all()
+
+    # differ only in the temporal component (regression: not_equal must OR)
+    v_t = vector.backends.numpy.VectorNumpy4D(
+        [(0.1, 0.2, 0.3, 0.5)],
+        dtype=[
+            ("x", numpy.float64),
+            ("y", numpy.float64),
+            ("z", numpy.float64),
+            ("t", numpy.float64),
+        ],
+    )
+    assert v1.not_equal(v_t).all()
+
+    # differ only in a spatial component (regression: not_equal must OR)
+    v_x = vector.backends.numpy.VectorNumpy4D(
+        [(0.9, 0.2, 0.3, 0.4)],
+        dtype=[
+            ("x", numpy.float64),
+            ("y", numpy.float64),
+            ("z", numpy.float64),
+            ("t", numpy.float64),
+        ],
+    )
+    assert v1.not_equal(v_x).all()
 
     for t1 in (
         "xyzt",


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Part of #711.

Fixes three predicate bugs in the backend-agnostic compute functions (shared by the object, numpy, awkward, sympy, and numba backends). Each fix is a pure `lib.*` expression, so it stays numba-compatible.

## 1. `not_equal` used AND instead of OR

The negation of "all components equal" is "any component differs" (OR), but the compute functions ANDed the per-component inequalities. The lorentz variant was doubly wrong: it ANDed the temporal inequality with a spatial *equal* check. It now mirrors `lorentz/equal.py` correctly: the temporal inequality is ORed with the spatial `not_equal`.

Files: `planar/not_equal.py`, all same-type signatures in `spatial/not_equal.py`, and `lorentz/not_equal.py`.

Before:
```python
>>> vector.obj(x=1.0, y=2.0) != vector.obj(x=1.0, y=3.0)
False   # but == is also False!
```
After:
```python
>>> vector.obj(x=1.0, y=2.0) != vector.obj(x=1.0, y=3.0)
True
```

## 2. `is_perpendicular` missing absolute value on the dot product

The predicate compared the signed dot product against the tolerance, so antiparallel vectors (`dot < 0`) were reported as perpendicular. The dot product is now wrapped in `lib.absolute`.

Files: `planar/is_perpendicular.py`, `spatial/is_perpendicular.py`.

Before:
```python
>>> vector.obj(x=1.0, y=0.0).is_perpendicular(vector.obj(x=-1.0, y=0.0))
True
```
After:
```python
>>> vector.obj(x=1.0, y=0.0).is_perpendicular(vector.obj(x=-1.0, y=0.0))
False
```

## 3. `is_spacelike` tolerance sign

`is_spacelike` used a `+abs(tolerance)` threshold, which overlaps with `is_lightlike`. It now uses `-abs(tolerance)` so that `is_timelike` (`dot > +tol`), `is_lightlike` (`|dot| < tol`), and `is_spacelike` (`dot < -tol`) partition the light cone without overlap, matching the docstring in `_methods.py`.

File: `lorentz/is_spacelike.py`.

Before:
```python
>>> v = vector.obj(x=1.0, y=0.0, z=0.0, t=1.0000001)
>>> v.is_spacelike(tolerance=1e-3), v.is_lightlike(tolerance=1e-3)
(True, True)   # overlap!
```
After:
```python
>>> v.is_spacelike(tolerance=1e-3), v.is_lightlike(tolerance=1e-3)
(False, True)
```

## Tests

Added regression tests covering single-component differences for `not_equal` (object, numpy, and sympy backends; both spatial and temporal differences in 4D), an antiparallel pair for `is_perpendicular` (object, numpy, and sympy; planar and spatial), and a nearly-lightlike timelike vector plus clearly timelike/spacelike vectors with a nonzero tolerance for `is_spacelike`.

`uv run pytest tests/compute/ tests/backends/test_object.py tests/backends/test_numpy.py tests/backends/test_numba_object.py` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)