### PR TITLE
perf: cache coordinate-type and handler lookups in dispatch

### DIFF
--- a/src/vector/_methods.py
+++ b/src/vector/_methods.py
@@ -3608,7 +3608,7 @@ class Spatial(Planar, VectorProtocolSpatial):
     ) -> ScalarCollection:
         from vector._compute.spatial import deltaangle
 
-        if dim(other) != 3 and dim(other) != 4:
+        if dim(other) not in (3, 4):
             raise TypeError(f"{other!r} is not a 3D or a 4D vector")
         return deltaangle.dispatch(self, other)
 
@@ -3617,7 +3617,7 @@ class Spatial(Planar, VectorProtocolSpatial):
     ) -> ScalarCollection:
         from vector._compute.spatial import deltaeta
 
-        if dim(other) != 3 and dim(other) != 4:
+        if dim(other) not in (3, 4):
             raise TypeError(f"{other!r} is not a 3D or a 4D vector")
         return deltaeta.dispatch(self, other)
 
@@ -3626,7 +3626,7 @@ class Spatial(Planar, VectorProtocolSpatial):
     ) -> ScalarCollection:
         from vector._compute.spatial import deltaR
 
-        if dim(other) != 3 and dim(other) != 4:
+        if dim(other) not in (3, 4):
             raise TypeError(f"{other!r} is not a 3D or a 4D vector")
         return deltaR.dispatch(self, other)
 
@@ -3635,7 +3635,7 @@ class Spatial(Planar, VectorProtocolSpatial):
     ) -> ScalarCollection:
         from vector._compute.spatial import deltaR2
 
-        if dim(other) != 3 and dim(other) != 4:
+        if dim(other) not in (3, 4):
             raise TypeError(f"{other!r} is not a 3D or a 4D vector")
         return deltaR2.dispatch(self, other)
 
@@ -4354,14 +4354,30 @@ _coordinate_order = [
 ]
 
 
+# Caches mapping a concrete coordinate class to its marker type. These are
+# keyed on the concrete ``type(...)`` of a coordinate object, which is fixed at
+# import time apart from rare third-party subclasses; caching by concrete type
+# means later-defined subclasses are looked up correctly on first use. A plain
+# dict is safe under free-threading because the computed values are
+# deterministic, so a racing get-then-set can only ever store identical values.
+_aztype_cache: dict[type, type[Coordinates]] = {}
+_ltype_cache: dict[type, type[Coordinates]] = {}
+_ttype_cache: dict[type, type[Coordinates]] = {}
+
+
 def _aztype(obj: VectorProtocolPlanar) -> type[Coordinates]:
     """
     Determines the Azimuthal type of a vector for use in looking up a
     dispatched function.
     """
     if hasattr(obj, "azimuthal"):
-        for t in type(obj.azimuthal).__mro__:
+        coord_type = type(obj.azimuthal)
+        cached = _aztype_cache.get(coord_type)
+        if cached is not None:
+            return cached
+        for t in coord_type.__mro__:
             if t in (AzimuthalXY, AzimuthalRhoPhi):
+                _aztype_cache[coord_type] = t
                 return t
     raise AssertionError(repr(obj))
 
@@ -4372,8 +4388,13 @@ def _ltype(obj: VectorProtocolSpatial) -> type[Coordinates]:
     dispatched function.
     """
     if hasattr(obj, "longitudinal"):
-        for t in type(obj.longitudinal).__mro__:
+        coord_type = type(obj.longitudinal)
+        cached = _ltype_cache.get(coord_type)
+        if cached is not None:
+            return cached
+        for t in coord_type.__mro__:
             if t in (LongitudinalZ, LongitudinalTheta, LongitudinalEta):
+                _ltype_cache[coord_type] = t
                 return t
     raise AssertionError(repr(obj))
 
@@ -4384,8 +4405,13 @@ def _ttype(obj: VectorProtocolLorentz) -> type[Coordinates]:
     dispatched function.
     """
     if hasattr(obj, "temporal"):
-        for t in type(obj.temporal).__mro__:
+        coord_type = type(obj.temporal)
+        cached = _ttype_cache.get(coord_type)
+        if cached is not None:
+            return cached
+        for t in coord_type.__mro__:
             if t in (TemporalT, TemporalTau):
+                _ttype_cache[coord_type] = t
                 return t
     raise AssertionError(repr(obj))
 
@@ -4434,11 +4460,23 @@ _handler_priority = [
 ]
 
 
+# Caches mapping a concrete vector class to its handler-priority index. Keyed on
+# the concrete ``type(...)`` for the same reasons (and with the same
+# free-threading safety) as the coordinate-type caches above.
+_handler_index_cache: dict[type, int] = {}
+
+
 def _get_handler_index(obj: VectorProtocol) -> int:
     """Returns the index of the first valid handler checking the list of parent classes"""
-    for cls in type(obj).__mro__:
+    obj_type = type(obj)
+    cached = _handler_index_cache.get(obj_type)
+    if cached is not None:
+        return cached
+    for cls in obj_type.__mro__:
         with suppress(ValueError):
-            return _handler_priority.index(cls.__module__)
+            index = _handler_priority.index(cls.__module__)
+            _handler_index_cache[obj_type] = index
+            return index
     raise AssertionError(
         f"Could not find a valid handler for {obj}! This should not happen."
     )


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Every dispatched operation (every property/method on every vector) goes through `_aztype`/`_ltype`/`_ttype`, which `hasattr`-check and then linearly scan the coordinate object's `type(...).__mro__` against a small fixed set of marker classes. Binary ops additionally call `_handler_of`, which calls `_get_handler_index` per operand — an MRO walk plus a `list.index` over `_handler_priority`.

The concrete coordinate/backend type sets are tiny and fixed at import time (apart from rare third-party subclasses), so this work is recomputed identically on every call. This PR caches the result per concrete type in module-level dicts, falling back to the existing MRO scan on a miss.

- Caching by **concrete type** keeps correct behavior for later-defined subclasses (they get their own cache entry on first use).
- A plain dict is safe under free-threading (3.14t): the cached values are deterministic, so a racing get-then-set can only ever store identical values.
- Public behavior is unchanged, including raising `AssertionError` for vectors lacking the relevant coordinate.

Also collapses the redundant double `dim(other)` calls in `deltaangle`/`deltaeta`/`deltaR`/`deltaR2` (`dim(other) != 3 and dim(other) != 4` → `dim(other) not in (3, 4)`).

## Benchmark

`timeit` microbenchmark (`/tmp/bench_dispatch.py`), best of two runs, lower is better:

| case                  | main (before) | branch (after) | speedup |
|-----------------------|--------------:|---------------:|--------:|
| object `deltaR`       |    15.65 us/op |     14.63 us/op |   ~7% |
| object `v1 + v2`      |     3.98 us/op |      2.93 us/op |  ~26% |
| numpy[10] `deltaR`    |    23.19 us/op |     21.90 us/op |   ~6% |
| numpy[10] `a1 + a2`   |    10.77 us/op |      9.69 us/op |  ~10% |

Binary `add` benefits most because it exercises `_handler_of` → `_get_handler_index` (two operands), which previously did an MRO walk + `list.index` per operand.

## Testing

- `uv run pytest --ignore=tests/test_notebooks.py -q`: 811 passed, 3 skipped.
- `prek -a --quiet` (incl. `mypy --strict`): clean.

Part of #711

🤖 Generated with [Claude Code](https://claude.com/claude-code)
