### PR TITLE
fix: symbolic sign, Max/Min, and numeric copysign in the SymPy backend

### DIFF
--- a/src/vector/_pytree.py
+++ b/src/vector/_pytree.py
@@ -1,3 +1,11 @@
+# Copyright (c) 2019, Saransh Chopra, Henry Schreiner, Eduardo Rodrigues, Jonas Eschle, and Jim Pivarski.
+#
+# Distributed under the 3-clause BSD license, see accompanying file LICENSE
+# or https://github.com/scikit-hep/vector for details.
+"""
+PyTree integration for vector types (optree support).
+"""
+
 from __future__ import annotations
 
 import functools

--- a/src/vector/backends/sympy.py
+++ b/src/vector/backends/sympy.py
@@ -1,3 +1,19 @@
+# Copyright (c) 2019, Saransh Chopra, Henry Schreiner, Eduardo Rodrigues, Jonas Eschle, and Jim Pivarski.
+#
+# Distributed under the 3-clause BSD license, see accompanying file LICENSE
+# or https://github.com/scikit-hep/vector for details.
+"""
+Defines behaviors for SymPy vectors. New vectors created with the respective classes
+
+.. code-block:: python
+
+    vector.VectorSympy2D(...)
+    vector.VectorSympy3D(...)
+    vector.VectorSympy4D(...)
+
+will have these behaviors built in (and will pass them to any derived objects).
+"""
+
 from __future__ import annotations
 
 import typing
@@ -47,10 +63,16 @@ class _lib:
         return val
 
     def maximum(self, val1: sympy.Expr | int, val2: sympy.Expr | int) -> sympy.Expr:
-        return val1 if isinstance(val1, sympy.Expr) else val2
+        # sympy.Max rejects nan, which numeric coordinates (from mixed
+        # sympy/object operations) can legitimately carry
+        if isinstance(val1, sympy.Expr) or isinstance(val2, sympy.Expr):
+            return sympy.Max(val1, val2)
+        return numpy.maximum(val1, val2)
 
     def minimum(self, val1: sympy.Expr | int, val2: sympy.Expr | int) -> sympy.Expr:
-        return val1 if isinstance(val1, sympy.Expr) else val2
+        if isinstance(val1, sympy.Expr) or isinstance(val2, sympy.Expr):
+            return sympy.Min(val1, val2)
+        return numpy.minimum(val1, val2)
 
     def arcsin(self, val: sympy.Expr) -> sympy.Expr:
         return sympy.asin(val)
@@ -85,15 +107,21 @@ class _lib:
         return sympy.Eq(val1, val2)
 
     def copysign(self, val1: sympy.Expr, val2: sympy.Expr) -> sympy.Expr:
-        return val1
+        # this assumes the sign carrier (val2) is non-negative, which holds for
+        # timelike vectors; a faithful Abs(val1)*sign(val2) translation makes
+        # sympy's simplifier choke on the nested Piecewise expressions that
+        # tau/t round-trips produce (see scikit-hep/vector#711)
+        if isinstance(val1, sympy.Expr) or isinstance(val2, sympy.Expr):
+            return val1
+        return numpy.copysign(val1, val2)
 
     @property
     def inf(self) -> sympy.Expr:
         return sympy.oo
 
     # same named functions
-    def sign(self, val: int | float) -> sympy.Expr:
-        return numpy.sign(val)
+    def sign(self, val: sympy.Expr | int | float) -> sympy.Expr:
+        return sympy.sign(val) if isinstance(val, sympy.Expr) else numpy.sign(val)
 
     def sqrt(self, val: sympy.Expr) -> sympy.Expr:
         return sympy.sqrt(val)
@@ -822,8 +850,8 @@ class VectorSympy2D(VectorSympy, Planar, Vector2D):
             azcoords = _coord_sympy_type[returns[0]](result[0], result[1])
             return cls.ProjectionClass2D(azimuthal=azcoords)
 
-        elif len(returns) == 2 or (
-            (len(returns) == 3 and returns[2] is None)
+        elif (
+            (len(returns) == 2 or (len(returns) == 3 and returns[2] is None))
             and isinstance(returns[0], type)
             and issubclass(returns[0], Azimuthal)
             and isinstance(returns[1], type)
@@ -1026,8 +1054,8 @@ class VectorSympy3D(VectorSympy, Spatial, Vector3D):
             azcoords = _coord_sympy_type[returns[0]](result[0], result[1])
             return cls.ProjectionClass2D(azimuthal=azcoords)
 
-        elif len(returns) == 2 or (
-            (len(returns) == 3 and returns[2] is None)
+        elif (
+            (len(returns) == 2 or (len(returns) == 3 and returns[2] is None))
             and isinstance(returns[0], type)
             and issubclass(returns[0], Azimuthal)
             and isinstance(returns[1], type)

--- a/tests/backends/test_sympy.py
+++ b/tests/backends/test_sympy.py
@@ -5,6 +5,8 @@
 
 from __future__ import annotations
 
+import math
+
 import pytest
 
 import vector
@@ -503,6 +505,15 @@ def test_lib_maximum_minimum_symbolic():
     assert lib.minimum(a, b) == sympy.Min(a, b)
     assert lib.maximum(a, 0).subs({a: -1}) == 0
     assert lib.minimum(a, 0).subs({a: -1}) == -1
+
+
+def test_lib_maximum_minimum_numeric():
+    # plain numbers (from mixed sympy/object operations) fall back to numpy,
+    # which sympy.Max/Min would reject for nan
+    lib = vector.backends.sympy._lib()
+    assert lib.maximum(2.0, 5.0) == 5.0
+    assert lib.minimum(2.0, 5.0) == 2.0
+    assert math.isnan(lib.maximum(float("nan"), 1.0))  # numpy.maximum propagates nan
 
 
 def test_lib_copysign_numeric():

--- a/tests/backends/test_sympy.py
+++ b/tests/backends/test_sympy.py
@@ -124,7 +124,7 @@ def test_construction():
         with pytest.raises(TypeError):
             vec = vec_cls(bad=1, **coords)
 
-        assert vec.t == sympy.sqrt(tau**2 + x**2 + y**2 + z**2)
+        assert vec.t == sympy.sqrt(sympy.Max(0, tau**2 + x**2 + y**2 + z**2))
         assert vec.tau == tau
 
         assert isinstance(vec.temporal, vector.backends.sympy.TemporalSympyTau)
@@ -214,9 +214,9 @@ def test_construction():
         assert vec.m == M
         assert vec.M == M
         assert vec.mass == M
-        assert vec.e == sympy.sqrt(M**2 + px**2 + py**2 + pz**2)
-        assert sympy.sqrt(M**2 + px**2 + py**2 + pz**2) == vec.E
-        assert vec.energy == sympy.sqrt(M**2 + px**2 + py**2 + pz**2)
+        assert vec.e == sympy.sqrt(sympy.Max(0, M**2 + px**2 + py**2 + pz**2))
+        assert sympy.sqrt(sympy.Max(0, M**2 + px**2 + py**2 + pz**2)) == vec.E
+        assert vec.energy == sympy.sqrt(sympy.Max(0, M**2 + px**2 + py**2 + pz**2))
 
         assert isinstance(vec.temporal, vector.backends.sympy.TemporalSympyTau)
         assert vec.temporal.elements == (M,)
@@ -482,3 +482,32 @@ def test_setters():
     assert v.energy == 2 * energy
     v.E = 2 * E
     assert v.E == 2 * E
+
+
+def test_lib_sign_symbolic():
+    # https://github.com/scikit-hep/vector/issues/711
+    # _lib.sign delegated to numpy.sign, which raised on symbolic input
+    a = sympy.Symbol("a", real=True)
+    r = sympy.Symbol("r", positive=True)
+    vec = vector.VectorSympy2D(rho=r, phi=phi)
+    scaled = vec.scale(a)
+    assert scaled.rho.subs({r: 2, a: -3, phi: 0.5}) == 6
+    assert scaled.rho.subs({r: 2, a: 3, phi: 0.5}) == 6
+
+
+def test_lib_maximum_minimum_symbolic():
+    # maximum/minimum returned the first symbolic argument unconditionally
+    lib = vector.backends.sympy._lib()
+    a, b = sympy.symbols("a b", real=True)
+    assert lib.maximum(a, b) == sympy.Max(a, b)
+    assert lib.minimum(a, b) == sympy.Min(a, b)
+    assert lib.maximum(a, 0).subs({a: -1}) == 0
+    assert lib.minimum(a, 0).subs({a: -1}) == -1
+
+
+def test_lib_copysign_numeric():
+    # copysign returned the first argument unconditionally, even for plain
+    # numbers (symbolic input still assumes a non-negative sign carrier)
+    lib = vector.backends.sympy._lib()
+    assert lib.copysign(3.0, -2.0) == -3.0
+    assert lib.copysign(-3.0, 2.0) == 3.0

--- a/tests/compute/sympy/lorentz/test_Et.py
+++ b/tests/compute/sympy/lorentz/test_Et.py
@@ -68,8 +68,14 @@ def test_xy_theta_tau():
             sympy.sqrt(sympy.Abs(-(t**2) + x**2 + y**2 + z**2))
         ),
     )
-    assert vec.Et.simplify() == sympy.sqrt(x**2 + y**2) * sympy.sqrt(
-        x**2 + y**2 + z**2 + sympy.Abs(-(t**2) + x**2 + y**2 + z**2)
+    assert vec.Et.simplify() == sympy.sqrt(
+        x**4
+        + 2 * x**2 * y**2
+        + x**2 * z**2
+        + x**2 * sympy.Abs(-(t**2) + x**2 + y**2 + z**2)
+        + y**4
+        + y**2 * z**2
+        + y**2 * sympy.Abs(-(t**2) + x**2 + y**2 + z**2)
     ) / sympy.sqrt(x**2 + y**2 + z**2)
     assert vec.Et.subs(values).evalf() == pytest.approx(math.sqrt(80))
 

--- a/tests/compute/sympy/lorentz/test_Et2.py
+++ b/tests/compute/sympy/lorentz/test_Et2.py
@@ -91,9 +91,16 @@ def test_xy_eta_tau():
             sympy.sqrt(sympy.Abs(-(t**2) + x**2 + y**2 + z**2))
         ),
     )
-    assert vec.Et2.simplify() == 1.0 * x**2 + 1.0 * y**2 + sympy.Abs(
-        -(t**2) + x**2 + y**2 + z**2
+    _eta = sympy.asinh(z / sympy.sqrt(x**2 + y**2))
+    _expected = sympy.Max(
+        0,
+        (
+            sympy.Float(0.25) * (x**2 + y**2) * (sympy.exp(2 * _eta) + 1) ** 2
+            + sympy.exp(2 * _eta) * sympy.Abs(-(t**2) + x**2 + y**2 + z**2)
+        )
+        * sympy.exp(-2 * _eta),
     ) / (z**2 / (x**2 + y**2) + 1)
+    assert sympy.expand(vec.Et2.simplify() - _expected) == 0
     assert vec.Et2.subs(values).evalf() == pytest.approx(80)
 
 
@@ -167,7 +174,10 @@ def test_rhophi_eta_tau():
             sympy.sqrt(sympy.Abs(rho**2 - t**2 + z**2))
         ),
     )
-    assert vec.Et2.simplify() == 1.0 * rho**2 + sympy.Abs(rho**2 - t**2 + z**2) / (
-        1 + z**2 / rho**2
-    )
+    _expected = (
+        sympy.Float(4.0) * rho**2
+        + sympy.Float(4.0) * z**2
+        + 4 * sympy.Abs(rho**2 - t**2 + z**2)
+    ) / (4 * (1 + z**2 / rho**2))
+    assert sympy.expand(vec.Et2.simplify() - _expected) == 0
     assert vec.Et2.subs(values).evalf() == pytest.approx(80)

--- a/tests/compute/sympy/lorentz/test_beta.py
+++ b/tests/compute/sympy/lorentz/test_beta.py
@@ -63,11 +63,8 @@ def test_xy_theta_tau():
             sympy.sqrt(sympy.Abs(-(t**2) + x**2 + y**2 + z**2))
         ),
     )
-    assert vec.beta.simplify() == sympy.sqrt(
-        x**4 + 2 * x**2 * y**2 + x**2 * z**2 + y**4 + y**2 * z**2
-    ) / (
-        sympy.sqrt(x**2 + y**2)
-        * sympy.sqrt(x**2 + y**2 + z**2 + sympy.Abs(-(t**2) + x**2 + y**2 + z**2))
+    assert vec.beta.simplify() == sympy.sqrt(x**2 + y**2 + z**2) / sympy.sqrt(
+        x**2 + y**2 + z**2 + sympy.Abs(-(t**2) + x**2 + y**2 + z**2)
     )
     assert vec.beta.subs(values).evalf() == pytest.approx(0.5590169943749475)
 

--- a/tests/compute/sympy/lorentz/test_gamma.py
+++ b/tests/compute/sympy/lorentz/test_gamma.py
@@ -100,10 +100,13 @@ def test_xy_eta_tau():
         ),
     )
     assert vec.gamma == sympy.sqrt(
-        (0.5 + 0.5 * sympy.exp(-2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))) ** 2
-        * (x**2 + y**2)
-        * sympy.exp(2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))
-        + sympy.Abs(-(t**2) + x**2 + y**2 + z**2)
+        sympy.Max(
+            0,
+            (0.5 + 0.5 * sympy.exp(-2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))) ** 2
+            * (x**2 + y**2)
+            * sympy.exp(2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))
+            + sympy.Abs(-(t**2) + x**2 + y**2 + z**2),
+        )
     ) / sympy.sqrt(sympy.Abs(-(t**2) + x**2 + y**2 + z**2))
     assert vec.gamma.subs(values).evalf() == pytest.approx(1.2060453783110545)
 
@@ -186,9 +189,12 @@ def test_rhophi_eta_tau():
         ),
     )
     assert vec.gamma == sympy.sqrt(
-        rho**2
-        * (0.5 + 0.5 * sympy.exp(-2 * sympy.asinh(z / rho))) ** 2
-        * sympy.exp(2 * sympy.asinh(z / rho))
-        + sympy.Abs(rho**2 - t**2 + z**2)
+        sympy.Max(
+            0,
+            rho**2
+            * (0.5 + 0.5 * sympy.exp(-2 * sympy.asinh(z / rho))) ** 2
+            * sympy.exp(2 * sympy.asinh(z / rho))
+            + sympy.Abs(rho**2 - t**2 + z**2),
+        )
     ) / sympy.sqrt(sympy.Abs(rho**2 - t**2 + z**2))
     assert vec.gamma.subs(values).evalf() == pytest.approx(1.2060453783110545)

--- a/tests/compute/sympy/lorentz/test_t.py
+++ b/tests/compute/sympy/lorentz/test_t.py
@@ -92,10 +92,13 @@ def test_xy_eta_tau():
         ),
     )
     assert vec.t == sympy.sqrt(
-        (0.5 + 0.5 * sympy.exp(-2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))) ** 2
-        * (x**2 + y**2)
-        * sympy.exp(2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))
-        + sympy.Abs(-(t**2) + x**2 + y**2 + z**2)
+        sympy.Max(
+            0,
+            (0.5 + 0.5 * sympy.exp(-2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))) ** 2
+            * (x**2 + y**2)
+            * sympy.exp(2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))
+            + sympy.Abs(-(t**2) + x**2 + y**2 + z**2),
+        )
     )
     assert vec.t.subs(values).evalf() == pytest.approx(20)
 
@@ -171,9 +174,12 @@ def test_rhophi_eta_tau():
         ),
     )
     assert vec.t == sympy.sqrt(
-        rho**2
-        * (0.5 + 0.5 * sympy.exp(-2 * sympy.asinh(z / rho))) ** 2
-        * sympy.exp(2 * sympy.asinh(z / rho))
-        + sympy.Abs(rho**2 - t**2 + z**2)
+        sympy.Max(
+            0,
+            rho**2
+            * (0.5 + 0.5 * sympy.exp(-2 * sympy.asinh(z / rho))) ** 2
+            * sympy.exp(2 * sympy.asinh(z / rho))
+            + sympy.Abs(rho**2 - t**2 + z**2),
+        )
     )
     assert vec.t.subs(values).evalf() == pytest.approx(20)

--- a/tests/compute/sympy/lorentz/test_t2.py
+++ b/tests/compute/sympy/lorentz/test_t2.py
@@ -91,11 +91,13 @@ def test_xy_eta_tau():
             sympy.sqrt(sympy.Abs(-(t**2) + x**2 + y**2 + z**2))
         ),
     )
-    assert vec.t2 == (
-        0.5 + 0.5 * sympy.exp(-2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))
-    ) ** 2 * (x**2 + y**2) * sympy.exp(
-        2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2))
-    ) + sympy.Abs(-(t**2) + x**2 + y**2 + z**2)
+    assert vec.t2 == sympy.Max(
+        0,
+        (0.5 + 0.5 * sympy.exp(-2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))) ** 2
+        * (x**2 + y**2)
+        * sympy.exp(2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))
+        + sympy.Abs(-(t**2) + x**2 + y**2 + z**2),
+    )
     assert vec.t2.subs(values).evalf() == pytest.approx(400)
 
 
@@ -165,7 +167,9 @@ def test_rhophi_eta_tau():
             sympy.sqrt(sympy.Abs(rho**2 - t**2 + z**2))
         ),
     )
-    assert vec.t2.simplify() == 0.25 * rho**2 * (4 + 4 * z**2 / rho**2) + sympy.Abs(
-        rho**2 - t**2 + z**2
+    assert vec.t2.simplify() == sympy.Max(
+        0,
+        sympy.Float(0.25) * rho**2 * (4 + 4 * z**2 / rho**2)
+        + sympy.Abs(rho**2 - t**2 + z**2),
     )
     assert vec.t2.subs(values).evalf() == pytest.approx(400)

--- a/tests/compute/sympy/lorentz/test_to_beta3.py
+++ b/tests/compute/sympy/lorentz/test_to_beta3.py
@@ -101,11 +101,8 @@ def test_xy_theta_tau():
     assert out.y.simplify() == y / sympy.sqrt(
         x**2 + y**2 + z**2 + sympy.Abs(-(t**2) + x**2 + y**2 + z**2)
     )
-    assert out.z.simplify() == z * sympy.sqrt(x**2 + y**2) / sympy.sqrt(
-        x**2 * (x**2 + y**2 + z**2)
-        + x**2 * sympy.Abs(-(t**2) + x**2 + y**2 + z**2)
-        + y**2 * (x**2 + y**2 + z**2)
-        + y**2 * sympy.Abs(-(t**2) + x**2 + y**2 + z**2)
+    assert out.z.simplify() == z / sympy.sqrt(
+        x**2 + y**2 + z**2 + sympy.Abs(-(t**2) + x**2 + y**2 + z**2)
     )
     assert out.x.subs(values).evalf() == pytest.approx(3 / 20)
     assert out.y.subs(values).evalf() == pytest.approx(4 / 20)
@@ -146,37 +143,21 @@ def test_xy_eta_tau():
     assert isinstance(out, vector.backends.sympy.VectorSympy3D)
     assert type(vec.azimuthal) == type(out.azimuthal)  # noqa: E721
     assert type(vec.longitudinal) == type(out.longitudinal)  # noqa: E721
-    assert out.x == x / sympy.sqrt(
-        (0.5 + 0.5 * sympy.exp(-2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))) ** 2
-        * (x**2 + y**2)
-        * sympy.exp(2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))
-        + sympy.Abs(-(t**2) + x**2 + y**2 + z**2)
-    )
-    assert out.y == y / sympy.sqrt(
-        (0.5 + 0.5 * sympy.exp(-2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))) ** 2
-        * (x**2 + y**2)
-        * sympy.exp(2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))
-        + sympy.Abs(-(t**2) + x**2 + y**2 + z**2)
-    )
-    # TODO: why won't sympy equate the expressions without double
-    # simplifying?
-    assert (
-        sympy.simplify(
-            out.z
-            - z
-            * sympy.sqrt(
-                sympy.exp(2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))
-                / (
-                    0.25
-                    * (x**2 + y**2)
-                    * (sympy.exp(2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2))) + 1) ** 2
-                    + sympy.exp(2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))
-                    * sympy.Abs(-(t**2) + x**2 + y**2 + z**2)
-                )
-            )
-        )
-        == 0
-    )
+    _eta = sympy.asinh(z / sympy.sqrt(x**2 + y**2))
+    _t2_inner = (0.5 + 0.5 * sympy.exp(-2 * _eta)) ** 2 * (x**2 + y**2) * sympy.exp(
+        2 * _eta
+    ) + sympy.Abs(-(t**2) + x**2 + y**2 + z**2)
+    assert out.x == x / sympy.sqrt(sympy.Max(0, _t2_inner))
+    assert out.y == y / sympy.sqrt(sympy.Max(0, _t2_inner))
+    # out.z simplifies to z/sqrt(Max(0, inner)) but the inner uses a factored
+    # 0.25*(x**2+y**2) form that sympy won't equate structurally; use expand.
+    _e2 = sympy.exp(2 * _eta)
+    _em2 = sympy.exp(-2 * _eta)
+    _z_inner = (
+        sympy.Float(0.25) * (x**2 + y**2) * (_e2 + 1) ** 2
+        + _e2 * sympy.Abs(-(t**2) + x**2 + y**2 + z**2)
+    ) * _em2
+    assert sympy.expand(out.z.simplify() - z / sympy.sqrt(sympy.Max(0, _z_inner))) == 0
     assert out.x.subs(values).evalf() == pytest.approx(3 / 20)
     assert out.y.subs(values).evalf() == pytest.approx(4 / 20)
     assert out.z.subs(values).evalf() == pytest.approx(10 / 20)
@@ -260,17 +241,13 @@ def test_rhophi_theta_tau():
     assert isinstance(out, vector.backends.sympy.VectorSympy3D)
     assert type(vec.azimuthal) == type(out.azimuthal)  # noqa: E721
     assert type(vec.longitudinal) == type(out.longitudinal)  # noqa: E721
-    assert out.x == rho * sympy.cos(phi) / sympy.sqrt(
-        rho**2 / (-(z**2) / (x**2 + y**2 + z**2) + 1)
-        + sympy.Abs(-(t**2) + x**2 + y**2 + z**2)
-    )
-    assert out.y == rho * sympy.sin(phi) / sympy.sqrt(
-        rho**2 / (-(z**2) / (x**2 + y**2 + z**2) + 1)
-        + sympy.Abs(-(t**2) + x**2 + y**2 + z**2)
-    )
-    assert out.z.simplify() == rho * z / sympy.sqrt(
-        rho**2 * (x**2 + y**2 + z**2)
-        + (x**2 + y**2) * sympy.Abs(-(t**2) + x**2 + y**2 + z**2)
+    _abs = sympy.Abs(-(t**2) + x**2 + y**2 + z**2)
+    _t2_inner = rho**2 / (-(z**2) / (x**2 + y**2 + z**2) + 1) + _abs
+    assert out.x == rho * sympy.cos(phi) / sympy.sqrt(sympy.Max(0, _t2_inner))
+    assert out.y == rho * sympy.sin(phi) / sympy.sqrt(sympy.Max(0, _t2_inner))
+    _z_inner = (rho**2 * (x**2 + y**2 + z**2) + (x**2 + y**2) * _abs) / (x**2 + y**2)
+    assert out.z.simplify() == rho * z / (
+        sympy.sqrt(x**2 + y**2) * sympy.sqrt(sympy.Max(0, _z_inner))
     )
     assert out.x.subs(values).evalf() == pytest.approx(5 / 20)
     assert out.y.subs(values).evalf() == pytest.approx(0 / 20)
@@ -311,27 +288,14 @@ def test_rhophi_eta_tau():
     assert isinstance(out, vector.backends.sympy.VectorSympy3D)
     assert type(vec.azimuthal) == type(out.azimuthal)  # noqa: E721
     assert type(vec.longitudinal) == type(out.longitudinal)  # noqa: E721
-    assert out.x == rho * sympy.cos(phi) / sympy.sqrt(
-        rho**2
-        * (0.5 + 0.5 * sympy.exp(-2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))) ** 2
-        * sympy.exp(2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))
-        + sympy.Abs(-(t**2) + x**2 + y**2 + z**2)
-    )
-    assert out.y == rho * sympy.sin(phi) / sympy.sqrt(
-        rho**2
-        * (0.5 + 0.5 * sympy.exp(-2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))) ** 2
-        * sympy.exp(2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))
-        + sympy.Abs(-(t**2) + x**2 + y**2 + z**2)
-    )
+    _eta = sympy.asinh(z / sympy.sqrt(x**2 + y**2))
+    _t2_inner = rho**2 * (0.5 + 0.5 * sympy.exp(-2 * _eta)) ** 2 * sympy.exp(
+        2 * _eta
+    ) + sympy.Abs(-(t**2) + x**2 + y**2 + z**2)
+    assert out.x == rho * sympy.cos(phi) / sympy.sqrt(sympy.Max(0, _t2_inner))
+    assert out.y == rho * sympy.sin(phi) / sympy.sqrt(sympy.Max(0, _t2_inner))
     assert out.z == rho * z / (
-        sympy.sqrt(x**2 + y**2)
-        * sympy.sqrt(
-            rho**2
-            * (0.5 + 0.5 * sympy.exp(-2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2))))
-            ** 2
-            * sympy.exp(2 * sympy.asinh(z / sympy.sqrt(x**2 + y**2)))
-            + sympy.Abs(-(t**2) + x**2 + y**2 + z**2)
-        )
+        sympy.sqrt(x**2 + y**2) * sympy.sqrt(sympy.Max(0, _t2_inner))
     )
     assert out.x.subs(values).evalf() == pytest.approx(5 / 20)
     assert out.y.subs(values).evalf() == pytest.approx(0 / 20)

--- a/tests/compute/sympy/spatial/test_deltaangle.py
+++ b/tests/compute/sympy/spatial/test_deltaangle.py
@@ -27,8 +27,11 @@ def test_spatial_sympy():
         longitudinal=vector.backends.sympy.LongitudinalSympyZ(nz),
     )
     assert v1.deltaangle(v2) == sympy.acos(
-        (nx * x + ny * y + nz * z)
-        / (sympy.sqrt(nx**2 + ny**2 + nz**2) * sympy.sqrt(x**2 + y**2 + z**2))
+        sympy.Min(
+            1,
+            (nx * x + ny * y + nz * z)
+            / (sympy.sqrt(nx**2 + ny**2 + nz**2) * sympy.sqrt(x**2 + y**2 + z**2)),
+        )
     )
 
     for t1 in "xyz", "xytheta", "xyeta", "rhophiz", "rhophitheta", "rhophieta":
@@ -54,8 +57,11 @@ def test_lorentz_sympy():
         temporal=vector.backends.sympy.TemporalSympyT(t),
     )
     assert v1.deltaangle(v2) == sympy.acos(
-        (nx * x + ny * y + nz * z)
-        / (sympy.sqrt(nx**2 + ny**2 + nz**2) * sympy.sqrt(x**2 + y**2 + z**2))
+        sympy.Min(
+            1,
+            (nx * x + ny * y + nz * z)
+            / (sympy.sqrt(nx**2 + ny**2 + nz**2) * sympy.sqrt(x**2 + y**2 + z**2)),
+        )
     )
 
     for t1 in (


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Part of #711.

Fixes the SymPy backend's `_lib` shim and related issues:

## `sign` raised on symbolic input

`_lib.sign` delegated to `numpy.sign`, which cannot evaluate a symbolic relational. Repro (before):

```python
>>> r, a = sympy.Symbol("r", positive=True), sympy.Symbol("a", real=True)
>>> vector.VectorSympy2D(rho=r, phi=sympy.Symbol("phi", real=True)).scale(a)
TypeError: cannot determine truth value of Relational: a < 0
```

Now uses `sympy.sign` for symbolic input (numpy for plain numbers).

## `maximum`/`minimum` returned the first symbolic argument unconditionally

The two methods were byte-identical, so symbolic clamps were silently dropped — e.g. `deltaangle`'s `acos` domain clamp and the `t2`/`Mt2` floors. They now return `sympy.Max`/`sympy.Min` for symbolic input, and fall back to `numpy.maximum`/`numpy.minimum` for plain numbers (so `nan` from mixed sympy/object operations propagates instead of raising inside `sympy.Max`).

The exact-expression assertions in the sympy mirror tests were updated to the new honest forms (e.g. `acos(Min(1, ...))`, `sqrt(Max(0, tau**2 + ...))`). **No numeric `.subs(...).evalf()` expectation changed.**

## `copysign` — documented, deliberately *not* fully fixed

`copysign(val1, val2)` returning `val1` assumes the sign carrier is non-negative (true for timelike vectors). I attempted the faithful `Abs(val1) * sign(val2)` (and a `Piecewise` variant matching numpy's `copysign(x, 0) == +x`): both are mathematically right, but tau/t round-trips then produce nested `Piecewise` expressions that crash sympy's `piecewise_fold`/`simplify_logic` with `ValueError: The argument 'nan' is not comparable`, and degrade every tau-coordinate expression with unsimplifiable `sign(...)` factors. The shortcut is now explicitly commented (with a pointer to #711), and the numeric path (`copysign(3.0, -2.0)`) is handled correctly via `numpy.copysign`. A proper symbolic encoding of signed `tau` is left as a follow-up decision.

## Other

- Added the missing BSD-3 copyright headers to `src/vector/backends/sympy.py` and `src/vector/_pytree.py`.
- Fixed an operator-precedence bug in two `_wrap_result` branch conditions (the `isinstance`/`issubclass` guards bound to only one arm of the `or`; latent today, aligned with the correct parenthesization in `numpy.py`).
- New regression tests: symbolic `scale`, symbolic `Max`/`Min`, numeric `copysign`.

Tests: full suite 814 passed, 3 skipped (unrelated optional deps); `prek -a` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
