### PR TITLE
Add guards for spatial conversion assignment warnings

### DIFF
--- a/src/vector/_compute/spatial/cross.py
+++ b/src/vector/_compute/spatial/cross.py
@@ -58,44 +58,69 @@ def make_conversion(azimuthal1, longitudinal1, azimuthal2, longitudinal2):
         AzimuthalXY,
         LongitudinalZ,
     ):
+        to_x1 = None
+        to_y1 = None
+        to_z1 = None
+        to_x2 = None
+        to_y2 = None
+        to_z2 = None
+
         if azimuthal1 is AzimuthalXY:
             to_x1 = x.xy
             to_y1 = y.xy
+
             if longitudinal1 is LongitudinalZ:
                 to_z1 = z.xy_z
             elif longitudinal1 is LongitudinalTheta:
                 to_z1 = z.xy_theta
             elif longitudinal1 is LongitudinalEta:
                 to_z1 = z.xy_eta
+
         elif azimuthal1 is AzimuthalRhoPhi:
             to_x1 = x.rhophi
             to_y1 = y.rhophi
+
             if longitudinal1 is LongitudinalZ:
                 to_z1 = z.rhophi_z
             elif longitudinal1 is LongitudinalTheta:
                 to_z1 = z.rhophi_theta
             elif longitudinal1 is LongitudinalEta:
                 to_z1 = z.rhophi_eta
+
         if azimuthal2 is AzimuthalXY:
             to_x2 = x.xy
             to_y2 = y.xy
+
             if longitudinal2 is LongitudinalZ:
                 to_z2 = z.xy_z
             elif longitudinal2 is LongitudinalTheta:
                 to_z2 = z.xy_theta
             elif longitudinal2 is LongitudinalEta:
                 to_z2 = z.xy_eta
+
         elif azimuthal2 is AzimuthalRhoPhi:
             to_x2 = x.rhophi
             to_y2 = y.rhophi
+
             if longitudinal2 is LongitudinalZ:
                 to_z2 = z.rhophi_z
             elif longitudinal2 is LongitudinalTheta:
                 to_z2 = z.rhophi_theta
             elif longitudinal2 is LongitudinalEta:
                 to_z2 = z.rhophi_eta
+
+        assert to_x1 is not None
+        assert to_y1 is not None
+        assert to_z1 is not None
+        assert to_x2 is not None
+        assert to_y2 is not None
+        assert to_z2 is not None
+
         cartesian, azout, lout, tout = dispatch_map[
-            AzimuthalXY, LongitudinalZ, AzimuthalXY, LongitudinalZ
+            AzimuthalXY,
+            LongitudinalZ,
+            AzimuthalXY,
+            LongitudinalZ,
         ]
 
         def f(lib, coord11, coord12, coord13, coord21, coord22, coord23):

--- a/src/vector/_compute/spatial/rotate_quaternion.py
+++ b/src/vector/_compute/spatial/rotate_quaternion.py
@@ -65,24 +65,36 @@ dispatch_map = {
 
 def make_conversion(azimuthal, longitudinal):
     if (azimuthal, longitudinal) != (AzimuthalXY, LongitudinalZ):
+        to_x = None
+        to_y = None
+        to_z = None
+
         if azimuthal is AzimuthalXY:
             to_x = x.xy
             to_y = y.xy
+
             if longitudinal is LongitudinalZ:
                 to_z = z.xy_z
             elif longitudinal is LongitudinalTheta:
                 to_z = z.xy_theta
             elif longitudinal is LongitudinalEta:
                 to_z = z.xy_eta
+
         elif azimuthal is AzimuthalRhoPhi:
             to_x = x.rhophi
             to_y = y.rhophi
+
             if longitudinal is LongitudinalZ:
                 to_z = z.rhophi_z
             elif longitudinal is LongitudinalTheta:
                 to_z = z.rhophi_theta
             elif longitudinal is LongitudinalEta:
                 to_z = z.rhophi_eta
+
+        assert to_x is not None
+        assert to_y is not None
+        assert to_z is not None
+
         cartesian, azout, lout = dispatch_map[AzimuthalXY, LongitudinalZ]
 
         def f(lib, u, i, j, k, coord1, coord2, coord3):


### PR DESCRIPTION
## Description

Adds targeted guards for a small subset of the Pylint use-before-assignment warnings reported in #512.

This PR focuses only on the spatial conversion helpers in:

* `src/vector/_compute/spatial/rotate_quaternion.py`
* `src/vector/_compute/spatial/cross.py`

The changes initialize conditionally assigned conversion callables before the coordinate-system branches and assert that each required callable was resolved before use. This keeps behavior unchanged for supported coordinate-system combinations while giving clearer failures if an unsupported branch reaches the conversion code.

Related issue: Part of #512

## Checklist

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't any other open Pull Requests for the required change?
* [ ] Does your submission pass pre-commit? (`$ pre-commit run --all-files` or `$ nox -s lint`)
* [ ] Does your submission pass tests? (`$ pytest` or `$ nox -s tests`)
* [ ] Does the documentation build with your changes? (`$ cd docs; make clean; make html` or `$ nox -s docs`)
* [ ] Does your submission pass the doctests? (`$ pytest --doctest-plus src/vector/` or `$ nox -s doctests`)

## Before Merging

* [ ] Summarize the commit messages into a brief review of the Pull request.
