### PR TITLE
fix: make dispatch chains in numba object backend exhaustive

### DIFF
--- a/src/vector/backends/_numba_object.py
+++ b/src/vector/backends/_numba_object.py
@@ -1431,6 +1431,9 @@ def add_binary_method(vectortype, gn, methodname):
             coord23 = getcoord1[numba_ltype(v2)]
             coord24 = getcoord1[numba_ttype(v2)]
 
+        else:
+            raise AssertionError
+
         if groupname == "planar":
             signature = (numba_aztype(v1), numba_aztype(v2))
 
@@ -1451,6 +1454,9 @@ def add_binary_method(vectortype, gn, methodname):
                 numba_ltype(v2),
                 numba_ttype(v2),
             )
+
+        else:
+            raise AssertionError
 
         function, *returns = _from_signature(
             groupname + "." + methodname,
@@ -1639,6 +1645,9 @@ def add_tolerance_method(vectortype, methodname):
             coord22 = getcoord2[numba_aztype(v2)]
             coord23 = getcoord1[numba_ltype(v2)]
 
+        else:
+            raise AssertionError
+
         function, *_ = _from_signature(
             groupname + "." + methodname,
             numba_modules[groupname][methodname],
@@ -1788,6 +1797,9 @@ def add_isclose_method(vectortype):
                     coord24(v2),
                 )
 
+        else:
+            raise AssertionError
+
         return overloader_impl
 
 
@@ -1897,6 +1909,9 @@ def add_transform2D(vectortype):
                     coord2(v),
                 )
                 return instance_class(azcoords(out1, out2), v.longitudinal, v.temporal)
+
+        else:
+            raise AssertionError
 
         return overloader_impl
 


### PR DESCRIPTION
Adds terminal `else: raise AssertionError` branches to the dimension/groupname dispatch chains in `vector/backends/_numba_object.py` that pylint flags as E0606 (`possibly-used-before-assignment`).

The chains are exhaustive at runtime — dimensions are always 2, 3, or 4, and `isclose` already validates matching dimensions with a `numba.TypingError` upstream — so the new branches are unreachable guards. Bare `raise AssertionError` matches the module's existing convention for impossible states (top of the module).

**Verification**
- `pylint --enable=E0606` on the file: 9 warnings → 0 (score 9.70 → 9.93)
- `tests/backends/test_numba_object.py`: 45 passed
- full suite with awkward+numba installed (notebooks excluded): 5252 passed, 65 skipped

Fixes #512