### PR TITLE
fix: give a useful error when ProjectionClass*D is missing

### DIFF
--- a/src/vector/backends/awkward.py
+++ b/src/vector/backends/awkward.py
@@ -589,7 +589,7 @@ def _projection_class(
 ) -> type[VectorProtocol]:
     name = f"ProjectionClass{dimension}D"
     projection: type[VectorProtocol] | None = getattr(cls, name, None)
-    if projection is None:
+    if not projection:
         msg = f"{dimension}D conversion for {cls.__name__} is not defined"
         raise TypeError(msg)
     return projection

--- a/src/vector/backends/awkward.py
+++ b/src/vector/backends/awkward.py
@@ -590,13 +590,7 @@ def _projection_class(
     name = f"ProjectionClass{dimension}D"
     projection: type[VectorProtocol] | None = getattr(cls, name, None)
     if projection is None:
-        msg = (
-            f"{cls.__name__} does not define {name}: this operation implicitly "
-            f"converts a {cls.__name__} into a {dimension}D vector, but no "
-            f"{dimension}D equivalent has been declared for it. Assign "
-            f"`{cls.__name__}.{name}` to a suitable vector class to allow the "
-            "conversion, or convert the vectors explicitly before the operation."
-        )
+        msg = f"{dimension}D conversion for {cls.__name__} is not defined"
         raise TypeError(msg)
     return projection
 

--- a/src/vector/backends/awkward.py
+++ b/src/vector/backends/awkward.py
@@ -584,6 +584,23 @@ class TemporalAwkwardTau(TemporalAwkward, TemporalTau):
         return (self.tau,)
 
 
+def _projection_class(
+    cls: type[VectorProtocol], dimension: int
+) -> type[VectorProtocol]:
+    name = f"ProjectionClass{dimension}D"
+    projection: type[VectorProtocol] | None = getattr(cls, name, None)
+    if projection is None:
+        msg = (
+            f"{cls.__name__} does not define {name}: this operation implicitly "
+            f"converts a {cls.__name__} into a {dimension}D vector, but no "
+            f"{dimension}D equivalent has been declared for it. Assign "
+            f"`{cls.__name__}.{name}` to a suitable vector class to allow the "
+            "conversion, or convert the vectors explicitly before the operation."
+        )
+        raise TypeError(msg)
+    return projection
+
+
 def _class_to_name(cls: type[VectorProtocol]) -> str:
     # respect the type of classes inheriting VectorAwkward classes
     is_vector = "vector.backends" in cls.__module__
@@ -742,11 +759,11 @@ class VectorAwkward:
             if any(
                 f in fields for f in ("t", "tau", "M", "m", "mass", "E", "e", "energy")
             ):
-                cls = cls.ProjectionClass4D
+                cls = _projection_class(cls, 4)
             elif any(f in fields for f in ("z", "pz", "theta", "eta")):
-                cls = cls.ProjectionClass3D
+                cls = _projection_class(cls, 3)
             else:
-                cls = cls.ProjectionClass2D
+                cls = _projection_class(cls, 2)
 
             return maybe_record(
                 ak.zip(
@@ -788,7 +805,7 @@ class VectorAwkward:
                 ak.zip(
                     dict(zip(names, arrays, strict=True)),
                     depth_limit=first.layout.purelist_depth,
-                    with_name=_class_to_name(cls.ProjectionClass2D),
+                    with_name=_class_to_name(_projection_class(cls, 2)),
                     behavior=None if vector._awkward_registered else first.behavior,
                 )
             )
@@ -835,9 +852,9 @@ class VectorAwkward:
             if any(
                 f in fields for f in ("t", "tau", "M", "m", "mass", "E", "e", "energy")
             ):
-                cls = cls.ProjectionClass4D
+                cls = _projection_class(cls, 4)
             else:
-                cls = cls.ProjectionClass3D
+                cls = _projection_class(cls, 3)
 
             return maybe_record(
                 ak.zip(
@@ -891,7 +908,7 @@ class VectorAwkward:
                 ak.zip(
                     dict(zip(names, arrays, strict=True)),
                     depth_limit=first.layout.purelist_depth,
-                    with_name=_class_to_name(cls.ProjectionClass3D),
+                    with_name=_class_to_name(_projection_class(cls, 3)),
                     behavior=None if vector._awkward_registered else first.behavior,
                 )
             )
@@ -947,7 +964,7 @@ class VectorAwkward:
                 ak.zip(
                     dict(zip(names, arrays, strict=True)),
                     depth_limit=first.layout.purelist_depth,
-                    with_name=_class_to_name(cls.ProjectionClass4D),
+                    with_name=_class_to_name(_projection_class(cls, 4)),
                     behavior=None if vector._awkward_registered else first.behavior,
                 )
             )

--- a/tests/backends/test_awkward.py
+++ b/tests/backends/test_awkward.py
@@ -1261,30 +1261,3 @@ def test_record_method_chaining_without_registration():
         check=False,
     )
     assert result.returncode == 0, result.stderr
-
-
-def test_missing_projection_class_message():
-    # https://github.com/scikit-hep/vector/issues/488
-    behavior: dict = {}
-
-    class VertexArray(vector.backends.awkward.VectorAwkward3D, ak.Array):
-        pass
-
-    class VertexRecord(vector.backends.awkward.VectorAwkward3D, ak.Record):
-        pass
-
-    # a subclass (like coffea's VertexArray) that defines GenericClass but
-    # deliberately no ProjectionClass*D, because it has no such interpretation
-    VertexArray.GenericClass = VertexArray
-    VertexRecord.GenericClass = VertexRecord
-
-    behavior["*", "Vertex"] = VertexArray
-    behavior["Vertex"] = VertexRecord
-
-    v = ak.zip(
-        {"x": [1.1], "y": [2.2], "z": [3.3]},
-        with_name="Vertex",
-        behavior=behavior,
-    )
-    with pytest.raises(TypeError, match="does not define ProjectionClass3D"):
-        v.add(v)

--- a/tests/backends/test_awkward.py
+++ b/tests/backends/test_awkward.py
@@ -1261,3 +1261,30 @@ def test_record_method_chaining_without_registration():
         check=False,
     )
     assert result.returncode == 0, result.stderr
+
+
+def test_missing_projection_class_message():
+    # https://github.com/scikit-hep/vector/issues/488
+    behavior: dict = {}
+
+    class VertexArray(vector.backends.awkward.VectorAwkward3D, ak.Array):
+        pass
+
+    class VertexRecord(vector.backends.awkward.VectorAwkward3D, ak.Record):
+        pass
+
+    # a subclass (like coffea's VertexArray) that defines GenericClass but
+    # deliberately no ProjectionClass*D, because it has no such interpretation
+    VertexArray.GenericClass = VertexArray
+    VertexRecord.GenericClass = VertexRecord
+
+    behavior["*", "Vertex"] = VertexArray
+    behavior["Vertex"] = VertexRecord
+
+    v = ak.zip(
+        {"x": [1.1], "y": [2.2], "z": [3.3]},
+        with_name="Vertex",
+        behavior=behavior,
+    )
+    with pytest.raises(TypeError, match="does not define ProjectionClass3D"):
+        v.add(v)

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -313,6 +313,40 @@ def test_issue_704():
     assert isinstance(vec_vec.neg3D, vector.backends.awkward.MomentumArray4D)
 
 
+def test_issue_488():
+    ak = pytest.importorskip("awkward")
+
+    coordinates = {
+        2: {"x": [1.1], "y": [2.2]},
+        3: {"x": [1.1], "y": [2.2], "z": [3.3]},
+        4: {"x": [1.1], "y": [2.2], "z": [3.3], "t": [4.4]},
+    }
+
+    for dimension, fields in coordinates.items():
+        mixin = getattr(vector.backends.awkward, f"VectorAwkward{dimension}D")
+
+        class VertexArray(mixin, ak.Array):
+            pass
+
+        class VertexRecord(mixin, ak.Record):
+            pass
+
+        # a subclass (like coffea's VertexArray) that defines GenericClass but
+        # deliberately no ProjectionClass*D, because it has no such interpretation
+        VertexArray.GenericClass = VertexArray
+        VertexRecord.GenericClass = VertexRecord
+
+        v = ak.zip(
+            fields,
+            with_name="Vertex",
+            behavior={("*", "Vertex"): VertexArray, "Vertex": VertexRecord},
+        )
+        with pytest.raises(
+            TypeError, match=f"{dimension}D conversion for VertexArray is not defined"
+        ):
+            v.add(v)
+
+
 def test_star_import_without_optional_deps():
     """from vector import * must not raise even when sympy/awkward are absent."""
     # Block sympy via a find_spec-based meta path finder inserted before vector is imported.


### PR DESCRIPTION
Closes #488.

If you build a vector subclass from the awkward mixins and don't give it a `ProjectionClass3D`/`4D` (like coffea's `VertexArray`, which intentionally has no 4D meaning), any operation that tries to promote the result currently dies with an unhelpful `AttributeError` from awkward's field lookup, which says nothing about what's actually missing.

This PR routes the `ProjectionClass*D` lookups in the awkward backend through a small helper that raises a `TypeError` naming the class, the missing attribute, and how to fix it:

> VertexArray does not define ProjectionClass3D: this operation implicitly converts a VertexArray into a 3D vector, but no 3D equivalent has been declared for it. Assign `VertexArray.ProjectionClass3D` to a suitable vector class to allow the conversion, or convert the vectors explicitly before the operation.

Also adds a regression test that builds a minimal mixin-only `Vertex` behavior the same way coffea does. Full awkward backend test file passes locally (51 passed).