### PR TITLE
perf(awkward): gather each operand's coordinates with one carry

### DIFF
--- a/src/vector/backends/awkward.py
+++ b/src/vector/backends/awkward.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 import functools
 import numbers
 import operator
+import threading
 import types
 import typing
 
@@ -624,6 +625,139 @@ _coordinate_fields_spatial = _azimuthal_fields | _longitudinal_fields
 _coordinate_fields_all = _azimuthal_fields | _longitudinal_fields | _temporal_fields
 
 
+_coordinate_field_groups = {
+    "azimuthal": _azimuthal_fields,
+    "longitudinal": _longitudinal_fields,
+    "temporal": _temporal_fields,
+}
+
+
+def _shared_index(record: typing.Any) -> typing.Any:
+    """
+    The one ``Index`` behind every field of ``record``, or None if the fields do
+    not all sit behind the same plain ``IndexedArray``.
+
+    ``RecordArray {f: Indexed(a), g: Indexed(b)}`` is what awkward's broadcasting
+    leaves behind after pushing an index inside a record; it is equivalent to
+    ``Indexed(RecordArray {f: a, g: b})``, which materializes with one index
+    kernel instead of one per field.
+    """
+    contents = record.contents
+    if not contents or record.is_tuple:
+        return None
+    first = contents[0]
+    if type(first) is not ak.contents.IndexedArray:
+        return None
+    for content in contents[1:]:
+        if type(content) is not ak.contents.IndexedArray or content.index is not (
+            first.index
+        ):
+            return None
+    return first.index
+
+
+def _can_one_carry(layout: typing.Any) -> bool:
+    """
+    Whether ``layout`` holds a record behind one shared index, i.e. whether a
+    one-carry gather has anything to collapse; if not, gathering only adds work.
+
+    Option types are excluded: ``IndexedOptionArray.project`` has to build a mask
+    as well, and the shapes it appears in are not the ones this optimizes.
+    """
+    if layout.is_option or layout.is_union or layout.is_numpy or layout.is_unknown:
+        return False
+    if layout.is_indexed:
+        return bool(layout.content.is_record)
+    if layout.is_record:
+        return _shared_index(layout) is not None
+    return _can_one_carry(layout.content)
+
+
+def _project_one_carry(layout: typing.Any) -> typing.Any:
+    """
+    Materialize the record inside ``layout`` with a single index lookup, or None
+    if it is not one of the shapes :func:`_can_one_carry` accepts.
+    """
+    if layout.is_option or layout.is_union or layout.is_numpy or layout.is_unknown:
+        return None
+    if layout.is_indexed:
+        return layout.project() if layout.content.is_record else None
+    if layout.is_record:
+        index = _shared_index(layout)
+        if index is None:
+            return None
+        # a RecordArray may be shorter than its fields; project only its own rows
+        return ak.contents.IndexedArray(
+            index[: layout.length],
+            ak.contents.RecordArray(
+                [content.content for content in layout.contents],
+                layout.fields,
+                parameters=layout._parameters,
+            ),
+        ).project()
+    content = _project_one_carry(layout.content)
+    return None if content is None else layout.copy(content=content)
+
+
+def _gather_coordinates(array: typing.Any, groups: typing.Iterable[str]) -> typing.Any:
+    """
+    Materialize exactly the coordinate fields that ``groups`` names, with a single
+    index lookup, or return None when there is nothing to gain.
+
+    Awkward projects an ``IndexedArray`` once per field asked of it, and every
+    projection re-runs the ``getitem_nextcarry`` kernel over the whole index. An
+    operation reading ``k`` fields of an indexed record therefore pays ``k`` index
+    kernels and ``k`` gathers; done once for the fields the dispatched function
+    actually reads it costs one kernel and the same ``k`` gathers. That index
+    kernel is most of the cost of arithmetic on ``ak.combinations``/
+    ``ak.cartesian`` output.
+    """
+    if not isinstance(array, ak.Array):
+        return None
+    layout = array.layout
+    # A typetracer has no data to gather, and gathering would touch buffers the
+    # calculation may not need (dask-awkward reads those touches to project columns).
+    if not layout.backend.nplike.known_data or not _can_one_carry(layout):
+        return None
+    wanted = frozenset().union(*(_coordinate_field_groups[group] for group in groups))
+    names = [name for name in layout.fields if name in wanted]
+    if len(names) < 2:
+        return None
+    # slicing first carries ``behavior`` (and named axes) over without rebuilding
+    # them, and drops the fields this operation does not read
+    selected = array[names]
+    projected = _project_one_carry(selected.layout)
+    if projected is None:
+        return None
+    selected.layout = projected
+    return selected
+
+
+class _Operand:
+    """One vector's coordinate objects for the duration of one dispatch."""
+
+    __slots__ = ("array", "coordinates", "groups", "source", "wrapped")
+
+    def __init__(self, array: typing.Any) -> None:
+        self.array = array
+        self.source = array
+        self.groups: set[str] = set()
+        self.coordinates: dict[str, typing.Any] = {}
+        # set by a wrap, cleared by the next request: a record still wrapped at
+        # the following wrap belongs to a dispatch that raised before its call
+        self.wrapped = False
+
+
+_dispatch_local = threading.local()
+
+
+def _dispatch_operands() -> dict[int, _Operand]:
+    operands: dict[int, _Operand] | None = getattr(_dispatch_local, "operands", None)
+    if operands is None:
+        operands = _dispatch_local.operands = {}
+    return operands
+
+
 def _yes_record(
     x: ak.Array,
 ) -> float | ak.Record | None:
@@ -663,6 +797,41 @@ class _lib(typing.NamedTuple):  # noqa: PLW1641
 
 class VectorAwkward:
     """Mixin class for Awkward vectors."""
+
+    def _coordinates(
+        self,
+        group: str,
+        from_fields: typing.Callable[[typing.Any], typing.Any],
+    ) -> typing.Any:
+        """
+        The ``azimuthal``/``longitudinal``/``temporal`` object, reused across the
+        dispatch that is asking for it.
+
+        A dispatch asks each operand for a coordinate group three times: twice to
+        look up the coordinate type (:func:`vector._methods._aztype` and friends
+        test with ``hasattr`` and then read the type) and once for the elements.
+        Recording the groups here is also how :meth:`_wrap_dispatched_function`
+        knows which fields the dispatched function will read: it is called after
+        the signature lookup and before the elements are taken.
+
+        Nothing is stored on ``self``; the record lives until the dispatch ends.
+        """
+        operands = _dispatch_operands()
+        operand = operands.get(id(self))
+        if operand is None or operand.array is not self:
+            operand = operands[id(self)] = _Operand(self)
+        operand.wrapped = False
+        coordinates = operand.coordinates
+        if group not in operand.groups:
+            operand.groups.add(group)
+            if operand.source is not operand.array:
+                # a dispatch that raised before taking its elements left a gather
+                # behind; it is narrower than what is being asked for now
+                operand.source = operand.array
+                coordinates.clear()
+        if group not in coordinates:
+            coordinates[group] = from_fields(operand.source)
+        return coordinates[group]
 
     @property
     def lib(self):  # type:ignore[no-untyped-def]
@@ -959,7 +1128,34 @@ class VectorAwkward:
         self: AwkwardProtocol,
         func: typing.Callable,  # type: ignore[type-arg]
     ) -> typing.Callable:  # type: ignore[type-arg]
-        return awkward_transform(func)
+        # Every ``dispatch`` calls this after looking the signature up (which asks
+        # each operand for the coordinate groups the chosen function reads, and no
+        # others) and before evaluating ``*v.azimuthal.elements`` and friends. So
+        # this is the one point where the needed field set is known and the
+        # elements have not been taken yet: gather each operand once, here.
+        operands = _dispatch_operands()
+        for key, operand in list(operands.items()):
+            if operand.wrapped:
+                # not asked for since the last wrap: that dispatch never ran its
+                # call, so its ``finally`` never cleared this record
+                del operands[key]
+                continue
+            operand.wrapped = True
+            if operand.source is not operand.array:
+                continue
+            gathered = _gather_coordinates(operand.array, operand.groups)
+            if gathered is not None:
+                operand.source = gathered
+                operand.coordinates.clear()
+        inner = awkward_transform(func)
+
+        def dispatched(*args: typing.Any, **kwargs: typing.Any) -> typing.Any:
+            try:
+                return inner(*args, **kwargs)
+            finally:
+                operands.clear()
+
+        return dispatched
 
 
 _placeholder = object()
@@ -1082,7 +1278,7 @@ class VectorAwkward2D(VectorAwkward, Planar, Vector2D):
             >>> a.azimuthal.elements
             (<Array [1, 2] type='2 * int64'>, <Array [1.1, 2.2] type='2 * float64'>)
         """
-        return AzimuthalAwkward.from_fields(self)
+        return self._coordinates("azimuthal", AzimuthalAwkward.from_fields)
 
 
 class MomentumAwkward2D(PlanarMomentum, VectorAwkward2D):
@@ -1112,7 +1308,7 @@ class MomentumAwkward2D(PlanarMomentum, VectorAwkward2D):
             >>> a.azimuthal.elements
             (<Array [1, 2] type='2 * int64'>, <Array [1.1, 2.2] type='2 * float64'>)
         """
-        return AzimuthalAwkward.from_momentum_fields(self)
+        return self._coordinates("azimuthal", AzimuthalAwkward.from_momentum_fields)
 
 
 class VectorAwkward3D(VectorAwkward, Spatial, Vector3D):
@@ -1142,7 +1338,7 @@ class VectorAwkward3D(VectorAwkward, Spatial, Vector3D):
             >>> a.azimuthal.elements
             (<Array [1, 2] type='2 * int64'>, <Array [1.1, 2.2] type='2 * float64'>)
         """
-        return AzimuthalAwkward.from_fields(self)
+        return self._coordinates("azimuthal", AzimuthalAwkward.from_fields)
 
     @property
     def longitudinal(self) -> LongitudinalAwkward:
@@ -1162,7 +1358,7 @@ class VectorAwkward3D(VectorAwkward, Spatial, Vector3D):
             >>> a.longitudinal.elements
             (<Array [0.1, 0.2] type='2 * float64'>,)
         """
-        return LongitudinalAwkward.from_fields(self)
+        return self._coordinates("longitudinal", LongitudinalAwkward.from_fields)
 
 
 class MomentumAwkward3D(SpatialMomentum, VectorAwkward3D):
@@ -1192,7 +1388,7 @@ class MomentumAwkward3D(SpatialMomentum, VectorAwkward3D):
             >>> a.azimuthal.elements
             (<Array [1, 2] type='2 * int64'>, <Array [1.1, 2.2] type='2 * float64'>)
         """
-        return AzimuthalAwkward.from_momentum_fields(self)
+        return self._coordinates("azimuthal", AzimuthalAwkward.from_momentum_fields)
 
     @property
     def longitudinal(self) -> LongitudinalAwkward:
@@ -1212,7 +1408,9 @@ class MomentumAwkward3D(SpatialMomentum, VectorAwkward3D):
             >>> a.longitudinal.elements
             (<Array [0.1, 0.2] type='2 * float64'>,)
         """
-        return LongitudinalAwkward.from_momentum_fields(self)
+        return self._coordinates(
+            "longitudinal", LongitudinalAwkward.from_momentum_fields
+        )
 
 
 class VectorAwkward4D(VectorAwkward, Lorentz, Vector4D):
@@ -1242,7 +1440,7 @@ class VectorAwkward4D(VectorAwkward, Lorentz, Vector4D):
             >>> a.azimuthal.elements
             (<Array [1, 2] type='2 * int64'>, <Array [1.1, 2.2] type='2 * float64'>)
         """
-        return AzimuthalAwkward.from_fields(self)
+        return self._coordinates("azimuthal", AzimuthalAwkward.from_fields)
 
     @property
     def longitudinal(self) -> LongitudinalAwkward:
@@ -1262,7 +1460,7 @@ class VectorAwkward4D(VectorAwkward, Lorentz, Vector4D):
             >>> a.longitudinal.elements
             (<Array [0.1, 0.2] type='2 * float64'>,)
         """
-        return LongitudinalAwkward.from_fields(self)
+        return self._coordinates("longitudinal", LongitudinalAwkward.from_fields)
 
     @property
     def temporal(self) -> TemporalAwkward:
@@ -1282,7 +1480,7 @@ class VectorAwkward4D(VectorAwkward, Lorentz, Vector4D):
             >>> a.temporal.elements
             (<Array [1, 3] type='2 * int64'>,)
         """
-        return TemporalAwkward.from_fields(self)
+        return self._coordinates("temporal", TemporalAwkward.from_fields)
 
 
 class MomentumAwkward4D(LorentzMomentum, VectorAwkward4D):
@@ -1312,7 +1510,7 @@ class MomentumAwkward4D(LorentzMomentum, VectorAwkward4D):
             >>> a.azimuthal.elements
             (<Array [1, 2] type='2 * int64'>, <Array [1.1, 2.2] type='2 * float64'>)
         """
-        return AzimuthalAwkward.from_momentum_fields(self)
+        return self._coordinates("azimuthal", AzimuthalAwkward.from_momentum_fields)
 
     @property
     def longitudinal(self) -> LongitudinalAwkward:
@@ -1332,7 +1530,9 @@ class MomentumAwkward4D(LorentzMomentum, VectorAwkward4D):
             >>> a.longitudinal.elements
             (<Array [0.1, 0.2] type='2 * float64'>,)
         """
-        return LongitudinalAwkward.from_momentum_fields(self)
+        return self._coordinates(
+            "longitudinal", LongitudinalAwkward.from_momentum_fields
+        )
 
     @property
     def temporal(self) -> TemporalAwkward:
@@ -1351,7 +1551,7 @@ class MomentumAwkward4D(LorentzMomentum, VectorAwkward4D):
             >>> a.temporal.elements
             (<Array [1, 3] type='2 * int64'>,)
         """
-        return TemporalAwkward.from_momentum_fields(self)
+        return self._coordinates("temporal", TemporalAwkward.from_momentum_fields)
 
 
 # ak.Array and ak.Record subclasses ###########################################

--- a/src/vector/backends/awkward.py
+++ b/src/vector/backends/awkward.py
@@ -35,7 +35,6 @@ from __future__ import annotations
 import functools
 import numbers
 import operator
-import threading
 import types
 import typing
 
@@ -625,139 +624,6 @@ _coordinate_fields_spatial = _azimuthal_fields | _longitudinal_fields
 _coordinate_fields_all = _azimuthal_fields | _longitudinal_fields | _temporal_fields
 
 
-_coordinate_field_groups = {
-    "azimuthal": _azimuthal_fields,
-    "longitudinal": _longitudinal_fields,
-    "temporal": _temporal_fields,
-}
-
-
-def _shared_index(record: typing.Any) -> typing.Any:
-    """
-    The one ``Index`` behind every field of ``record``, or None if the fields do
-    not all sit behind the same plain ``IndexedArray``.
-
-    ``RecordArray {f: Indexed(a), g: Indexed(b)}`` is what awkward's broadcasting
-    leaves behind after pushing an index inside a record; it is equivalent to
-    ``Indexed(RecordArray {f: a, g: b})``, which materializes with one index
-    kernel instead of one per field.
-    """
-    contents = record.contents
-    if not contents or record.is_tuple:
-        return None
-    first = contents[0]
-    if type(first) is not ak.contents.IndexedArray:
-        return None
-    for content in contents[1:]:
-        if type(content) is not ak.contents.IndexedArray or content.index is not (
-            first.index
-        ):
-            return None
-    return first.index
-
-
-def _can_one_carry(layout: typing.Any) -> bool:
-    """
-    Whether ``layout`` holds a record behind one shared index, i.e. whether a
-    one-carry gather has anything to collapse; if not, gathering only adds work.
-
-    Option types are excluded: ``IndexedOptionArray.project`` has to build a mask
-    as well, and the shapes it appears in are not the ones this optimizes.
-    """
-    if layout.is_option or layout.is_union or layout.is_numpy or layout.is_unknown:
-        return False
-    if layout.is_indexed:
-        return bool(layout.content.is_record)
-    if layout.is_record:
-        return _shared_index(layout) is not None
-    return _can_one_carry(layout.content)
-
-
-def _project_one_carry(layout: typing.Any) -> typing.Any:
-    """
-    Materialize the record inside ``layout`` with a single index lookup, or None
-    if it is not one of the shapes :func:`_can_one_carry` accepts.
-    """
-    if layout.is_option or layout.is_union or layout.is_numpy or layout.is_unknown:
-        return None
-    if layout.is_indexed:
-        return layout.project() if layout.content.is_record else None
-    if layout.is_record:
-        index = _shared_index(layout)
-        if index is None:
-            return None
-        # a RecordArray may be shorter than its fields; project only its own rows
-        return ak.contents.IndexedArray(
-            index[: layout.length],
-            ak.contents.RecordArray(
-                [content.content for content in layout.contents],
-                layout.fields,
-                parameters=layout._parameters,
-            ),
-        ).project()
-    content = _project_one_carry(layout.content)
-    return None if content is None else layout.copy(content=content)
-
-
-def _gather_coordinates(array: typing.Any, groups: typing.Iterable[str]) -> typing.Any:
-    """
-    Materialize exactly the coordinate fields that ``groups`` names, with a single
-    index lookup, or return None when there is nothing to gain.
-
-    Awkward projects an ``IndexedArray`` once per field asked of it, and every
-    projection re-runs the ``getitem_nextcarry`` kernel over the whole index. An
-    operation reading ``k`` fields of an indexed record therefore pays ``k`` index
-    kernels and ``k`` gathers; done once for the fields the dispatched function
-    actually reads it costs one kernel and the same ``k`` gathers. That index
-    kernel is most of the cost of arithmetic on ``ak.combinations``/
-    ``ak.cartesian`` output.
-    """
-    if not isinstance(array, ak.Array):
-        return None
-    layout = array.layout
-    # A typetracer has no data to gather, and gathering would touch buffers the
-    # calculation may not need (dask-awkward reads those touches to project columns).
-    if not layout.backend.nplike.known_data or not _can_one_carry(layout):
-        return None
-    wanted = frozenset().union(*(_coordinate_field_groups[group] for group in groups))
-    names = [name for name in layout.fields if name in wanted]
-    if len(names) < 2:
-        return None
-    # slicing first carries ``behavior`` (and named axes) over without rebuilding
-    # them, and drops the fields this operation does not read
-    selected = array[names]
-    projected = _project_one_carry(selected.layout)
-    if projected is None:
-        return None
-    selected.layout = projected
-    return selected
-
-
-class _Operand:
-    """One vector's coordinate objects for the duration of one dispatch."""
-
-    __slots__ = ("array", "coordinates", "groups", "source", "wrapped")
-
-    def __init__(self, array: typing.Any) -> None:
-        self.array = array
-        self.source = array
-        self.groups: set[str] = set()
-        self.coordinates: dict[str, typing.Any] = {}
-        # set by a wrap, cleared by the next request: a record still wrapped at
-        # the following wrap belongs to a dispatch that raised before its call
-        self.wrapped = False
-
-
-_dispatch_local = threading.local()
-
-
-def _dispatch_operands() -> dict[int, _Operand]:
-    operands: dict[int, _Operand] | None = getattr(_dispatch_local, "operands", None)
-    if operands is None:
-        operands = _dispatch_local.operands = {}
-    return operands
-
-
 def _yes_record(
     x: ak.Array,
 ) -> float | ak.Record | None:
@@ -797,41 +663,6 @@ class _lib(typing.NamedTuple):  # noqa: PLW1641
 
 class VectorAwkward:
     """Mixin class for Awkward vectors."""
-
-    def _coordinates(
-        self,
-        group: str,
-        from_fields: typing.Callable[[typing.Any], typing.Any],
-    ) -> typing.Any:
-        """
-        The ``azimuthal``/``longitudinal``/``temporal`` object, reused across the
-        dispatch that is asking for it.
-
-        A dispatch asks each operand for a coordinate group three times: twice to
-        look up the coordinate type (:func:`vector._methods._aztype` and friends
-        test with ``hasattr`` and then read the type) and once for the elements.
-        Recording the groups here is also how :meth:`_wrap_dispatched_function`
-        knows which fields the dispatched function will read: it is called after
-        the signature lookup and before the elements are taken.
-
-        Nothing is stored on ``self``; the record lives until the dispatch ends.
-        """
-        operands = _dispatch_operands()
-        operand = operands.get(id(self))
-        if operand is None or operand.array is not self:
-            operand = operands[id(self)] = _Operand(self)
-        operand.wrapped = False
-        coordinates = operand.coordinates
-        if group not in operand.groups:
-            operand.groups.add(group)
-            if operand.source is not operand.array:
-                # a dispatch that raised before taking its elements left a gather
-                # behind; it is narrower than what is being asked for now
-                operand.source = operand.array
-                coordinates.clear()
-        if group not in coordinates:
-            coordinates[group] = from_fields(operand.source)
-        return coordinates[group]
 
     @property
     def lib(self):  # type:ignore[no-untyped-def]
@@ -1128,34 +959,70 @@ class VectorAwkward:
         self: AwkwardProtocol,
         func: typing.Callable,  # type: ignore[type-arg]
     ) -> typing.Callable:  # type: ignore[type-arg]
-        # Every ``dispatch`` calls this after looking the signature up (which asks
-        # each operand for the coordinate groups the chosen function reads, and no
-        # others) and before evaluating ``*v.azimuthal.elements`` and friends. So
-        # this is the one point where the needed field set is known and the
-        # elements have not been taken yet: gather each operand once, here.
-        operands = _dispatch_operands()
-        for key, operand in list(operands.items()):
-            if operand.wrapped:
-                # not asked for since the last wrap: that dispatch never ran its
-                # call, so its ``finally`` never cleared this record
-                del operands[key]
-                continue
-            operand.wrapped = True
-            if operand.source is not operand.array:
-                continue
-            gathered = _gather_coordinates(operand.array, operand.groups)
-            if gathered is not None:
-                operand.source = gathered
-                operand.coordinates.clear()
-        inner = awkward_transform(func)
+        return awkward_transform(func)
 
-        def dispatched(*args: typing.Any, **kwargs: typing.Any) -> typing.Any:
-            try:
-                return inner(*args, **kwargs)
-            finally:
-                operands.clear()
 
-        return dispatched
+def _indexed_node(layout: typing.Any) -> typing.Any:
+    """
+    The plain ``IndexedArray`` over numbers that ``layout`` reaches through list
+    nodes only, or None.
+    """
+    while layout.is_list:
+        layout = layout.content
+    if (
+        type(layout) is ak.contents.IndexedArray
+        and layout.content.is_numpy
+        and not layout.parameters
+    ):
+        return layout
+    return None
+
+
+def _replace_indexed_node(layout: typing.Any, content: typing.Any) -> typing.Any:
+    if type(layout) is ak.contents.IndexedArray:
+        return content
+    return layout.copy(content=_replace_indexed_node(layout.content, content))
+
+
+def _gather_shared_indexes(arrays: list[ak.Array]) -> list[ak.Array]:
+    """
+    Materialize every group of ``arrays`` that sits behind the same ``Index``
+    with one index kernel.
+
+    Fields taken from one record behind an ``IndexedArray`` (what
+    ``ak.combinations``/``ak.cartesian`` produce, before or after broadcasting
+    pushes the index inside the record) all share the ``Index`` object. Left to
+    ``ak.transform``, each field runs the ``getitem_nextcarry`` kernel over the
+    whole index again; that kernel is most of the cost of arithmetic on such
+    arrays. Gathered as one tuple record, the group pays one kernel and the same
+    per-field carries.
+    """
+    groups: dict[int, list[int]] = {}
+    nodes: list[typing.Any] = []
+    for i, array in enumerate(arrays):
+        layout = array.layout
+        # a typetracer has no data to gather, and gathering would touch buffers the
+        # calculation may not need (dask-awkward reads those touches to project columns)
+        node = _indexed_node(layout) if layout.backend.nplike.known_data else None
+        nodes.append(node)
+        if node is not None:
+            groups.setdefault(id(node.index), []).append(i)
+    arrays = list(arrays)
+    for members in groups.values():
+        if len(members) < 2:
+            continue
+        projected = ak.contents.IndexedArray(
+            nodes[members[0]].index,
+            ak.contents.RecordArray([nodes[i].content for i in members], None),
+        ).project()
+        for k, i in enumerate(members):
+            # a copy keeps behavior and attrs; only the layout changes
+            gathered = ak.Array(arrays[i])
+            gathered.layout = _replace_indexed_node(
+                arrays[i].layout, projected.content(k)
+            )
+            arrays[i] = gathered
+    return arrays
 
 
 _placeholder = object()
@@ -1199,6 +1066,7 @@ class awkward_transform:
 
         # this means we're working with awkward-arrays and we should group operations with ak.transform
         if n_orig_akarrays > 0:
+            awkward_arrays = _gather_shared_indexes(awkward_arrays)
 
             def transformer(
                 layouts: ak.contents.Content | tuple[ak.contents.Content, ...],
@@ -1278,7 +1146,7 @@ class VectorAwkward2D(VectorAwkward, Planar, Vector2D):
             >>> a.azimuthal.elements
             (<Array [1, 2] type='2 * int64'>, <Array [1.1, 2.2] type='2 * float64'>)
         """
-        return self._coordinates("azimuthal", AzimuthalAwkward.from_fields)
+        return AzimuthalAwkward.from_fields(self)
 
 
 class MomentumAwkward2D(PlanarMomentum, VectorAwkward2D):
@@ -1308,7 +1176,7 @@ class MomentumAwkward2D(PlanarMomentum, VectorAwkward2D):
             >>> a.azimuthal.elements
             (<Array [1, 2] type='2 * int64'>, <Array [1.1, 2.2] type='2 * float64'>)
         """
-        return self._coordinates("azimuthal", AzimuthalAwkward.from_momentum_fields)
+        return AzimuthalAwkward.from_momentum_fields(self)
 
 
 class VectorAwkward3D(VectorAwkward, Spatial, Vector3D):
@@ -1338,7 +1206,7 @@ class VectorAwkward3D(VectorAwkward, Spatial, Vector3D):
             >>> a.azimuthal.elements
             (<Array [1, 2] type='2 * int64'>, <Array [1.1, 2.2] type='2 * float64'>)
         """
-        return self._coordinates("azimuthal", AzimuthalAwkward.from_fields)
+        return AzimuthalAwkward.from_fields(self)
 
     @property
     def longitudinal(self) -> LongitudinalAwkward:
@@ -1358,7 +1226,7 @@ class VectorAwkward3D(VectorAwkward, Spatial, Vector3D):
             >>> a.longitudinal.elements
             (<Array [0.1, 0.2] type='2 * float64'>,)
         """
-        return self._coordinates("longitudinal", LongitudinalAwkward.from_fields)
+        return LongitudinalAwkward.from_fields(self)
 
 
 class MomentumAwkward3D(SpatialMomentum, VectorAwkward3D):
@@ -1388,7 +1256,7 @@ class MomentumAwkward3D(SpatialMomentum, VectorAwkward3D):
             >>> a.azimuthal.elements
             (<Array [1, 2] type='2 * int64'>, <Array [1.1, 2.2] type='2 * float64'>)
         """
-        return self._coordinates("azimuthal", AzimuthalAwkward.from_momentum_fields)
+        return AzimuthalAwkward.from_momentum_fields(self)
 
     @property
     def longitudinal(self) -> LongitudinalAwkward:
@@ -1408,9 +1276,7 @@ class MomentumAwkward3D(SpatialMomentum, VectorAwkward3D):
             >>> a.longitudinal.elements
             (<Array [0.1, 0.2] type='2 * float64'>,)
         """
-        return self._coordinates(
-            "longitudinal", LongitudinalAwkward.from_momentum_fields
-        )
+        return LongitudinalAwkward.from_momentum_fields(self)
 
 
 class VectorAwkward4D(VectorAwkward, Lorentz, Vector4D):
@@ -1440,7 +1306,7 @@ class VectorAwkward4D(VectorAwkward, Lorentz, Vector4D):
             >>> a.azimuthal.elements
             (<Array [1, 2] type='2 * int64'>, <Array [1.1, 2.2] type='2 * float64'>)
         """
-        return self._coordinates("azimuthal", AzimuthalAwkward.from_fields)
+        return AzimuthalAwkward.from_fields(self)
 
     @property
     def longitudinal(self) -> LongitudinalAwkward:
@@ -1460,7 +1326,7 @@ class VectorAwkward4D(VectorAwkward, Lorentz, Vector4D):
             >>> a.longitudinal.elements
             (<Array [0.1, 0.2] type='2 * float64'>,)
         """
-        return self._coordinates("longitudinal", LongitudinalAwkward.from_fields)
+        return LongitudinalAwkward.from_fields(self)
 
     @property
     def temporal(self) -> TemporalAwkward:
@@ -1480,7 +1346,7 @@ class VectorAwkward4D(VectorAwkward, Lorentz, Vector4D):
             >>> a.temporal.elements
             (<Array [1, 3] type='2 * int64'>,)
         """
-        return self._coordinates("temporal", TemporalAwkward.from_fields)
+        return TemporalAwkward.from_fields(self)
 
 
 class MomentumAwkward4D(LorentzMomentum, VectorAwkward4D):
@@ -1510,7 +1376,7 @@ class MomentumAwkward4D(LorentzMomentum, VectorAwkward4D):
             >>> a.azimuthal.elements
             (<Array [1, 2] type='2 * int64'>, <Array [1.1, 2.2] type='2 * float64'>)
         """
-        return self._coordinates("azimuthal", AzimuthalAwkward.from_momentum_fields)
+        return AzimuthalAwkward.from_momentum_fields(self)
 
     @property
     def longitudinal(self) -> LongitudinalAwkward:
@@ -1530,9 +1396,7 @@ class MomentumAwkward4D(LorentzMomentum, VectorAwkward4D):
             >>> a.longitudinal.elements
             (<Array [0.1, 0.2] type='2 * float64'>,)
         """
-        return self._coordinates(
-            "longitudinal", LongitudinalAwkward.from_momentum_fields
-        )
+        return LongitudinalAwkward.from_momentum_fields(self)
 
     @property
     def temporal(self) -> TemporalAwkward:
@@ -1551,7 +1415,7 @@ class MomentumAwkward4D(LorentzMomentum, VectorAwkward4D):
             >>> a.temporal.elements
             (<Array [1, 3] type='2 * int64'>,)
         """
-        return self._coordinates("temporal", TemporalAwkward.from_momentum_fields)
+        return TemporalAwkward.from_momentum_fields(self)
 
 
 # ak.Array and ak.Record subclasses ###########################################

--- a/tests/backends/test_awkward.py
+++ b/tests/backends/test_awkward.py
@@ -1261,3 +1261,256 @@ def test_record_method_chaining_without_registration():
         check=False,
     )
     assert result.returncode == 0, result.stderr
+
+
+# ``vector.Array`` field name for each generic coordinate, per flavor.
+_MOMENTUM_NAMES = {
+    "x": "px",
+    "y": "py",
+    "rho": "pt",
+    "phi": "phi",
+    "z": "pz",
+    "theta": "theta",
+    "eta": "eta",
+    "t": "E",
+    "tau": "mass",
+}
+# Chosen so every coordinate system is well defined (rho > 0, 0 < theta < pi) and
+# no operation below produces a NaN, which would defeat the exact comparisons.
+_COORDINATE_VALUES = {
+    "x": [1.0, 4.0, 2.5, -1.0, 2.0],
+    "y": [2.0, 5.0, -1.5, 0.5, -3.0],
+    "rho": [1.5, 4.0, 2.5, 1.0, 2.0],
+    "phi": [0.1, -2.0, 3.0, 1.5, -0.5],
+    "z": [3.0, 6.0, -2.0, 2.0, 1.0],
+    "theta": [0.3, 1.2, 2.5, 1.0, 0.7],
+    "eta": [1.1, -0.4, 0.25, 2.0, -1.5],
+    "t": [10.0, 20.0, 15.0, 9.0, 11.0],
+    "tau": [1.0, 2.0, 0.5, 3.0, 1.5],
+}
+_COORDINATE_SYSTEMS = [
+    (azimuthal, longitudinal + temporal)
+    for azimuthal in (("x", "y"), ("rho", "phi"))
+    for longitudinal, temporals in (
+        ((), ((),)),
+        (("z",), ((), ("t",), ("tau",))),
+        (("theta",), ((), ("t",), ("tau",))),
+        (("eta",), ((), ("t",), ("tau",))),
+    )
+    for temporal in temporals
+]
+
+
+def _pairs(coordinates, *, momentum, with_none):
+    """``ak.combinations`` of vectors, i.e. records behind an ``IndexedArray``."""
+    names = _MOMENTUM_NAMES if momentum else dict.fromkeys(_COORDINATE_VALUES)
+    fields = {names[name] or name: _COORDINATE_VALUES[name] for name in coordinates}
+    # a non-coordinate field, to check that it is never gathered or carried along
+    fields["flag"] = [7.0, 8.0, 6.0, 9.0, 1.0]
+    array = ak.unflatten(ak.zip(fields), [3, 0, 2])
+    if with_none:
+        array = ak.Array([list(sublist) for sublist in array.to_list()])
+        array = ak.with_field(
+            array, ak.Array([[1.0, None, 3.0], [], [4.0, 5.0]]), "opt"
+        )
+        array = array[[name for name in array.fields if name != "opt"]]
+    return ak.combinations(vector.Array(array), 2, fields=["u", "v"])
+
+
+def _without_single_carry(monkeypatch):
+    """Restore the pre-optimization path: every coordinate field gathers itself."""
+    monkeypatch.setattr(
+        vector.backends.awkward, "_gather_coordinates", lambda array, groups: None
+    )
+
+
+def _carried_fields(monkeypatch, values):
+    """Names of the fields each ``NumpyArray._carry`` gathers, in call order."""
+    carried = []
+    tags = {np.float64(value).tobytes(): name for name, value in values.items()}
+    carry = ak.contents.NumpyArray._carry
+
+    def counted(self, *args, **kwargs):
+        carried.append(tags.get(self.data.tobytes()[:8], "?"))
+        return carry(self, *args, **kwargs)
+
+    monkeypatch.setattr(ak.contents.NumpyArray, "_carry", counted)
+    return carried
+
+
+@pytest.mark.parametrize("momentum", [False, True])
+@pytest.mark.parametrize("with_none", [False, True])
+@pytest.mark.parametrize(("azimuthal", "rest"), _COORDINATE_SYSTEMS)
+def test_single_carry_is_bit_identical(azimuthal, rest, momentum, with_none):
+    coordinates = azimuthal + rest
+    fast = _pairs(coordinates, momentum=momentum, with_none=with_none)
+    fast_sum = fast.u + fast.v
+    fast_scalar = fast.u.rho2
+
+    with pytest.MonkeyPatch.context() as patch:
+        _without_single_carry(patch)
+        slow = _pairs(coordinates, momentum=momentum, with_none=with_none)
+        slow_sum = slow.u + slow.v
+        slow_scalar = slow.u.rho2
+
+    assert str(fast_sum.type) == str(slow_sum.type)
+    assert fast_sum.to_list() == slow_sum.to_list()
+    assert str(fast_scalar.type) == str(slow_scalar.type)
+    assert fast_scalar.to_list() == slow_scalar.to_list()
+
+
+@pytest.mark.parametrize("momentum", [False, True])
+def test_single_carry_keeps_extra_fields_of_one_argument_ops(momentum):
+    fast = _pairs(("x", "y", "z", "t"), momentum=momentum, with_none=False)
+    fast_scaled = fast.u.scale(2.5)
+
+    with pytest.MonkeyPatch.context() as patch:
+        _without_single_carry(patch)
+        slow = _pairs(("x", "y", "z", "t"), momentum=momentum, with_none=False)
+        slow_scaled = slow.u.scale(2.5)
+
+    assert "flag" in fast_scaled.fields
+    assert str(fast_scaled.type) == str(slow_scaled.type)
+    assert fast_scaled.to_list() == slow_scaled.to_list()
+
+
+def test_coordinates_are_gathered_once_per_argument(monkeypatch):
+    pairs = _pairs(("x", "y", "z", "t"), momentum=False, with_none=False)
+    projections = []
+    project = ak.contents.IndexedArray.project
+
+    def counted(self, mask=None):
+        projections.append(self)
+        return project(self, mask)
+
+    monkeypatch.setattr(ak.contents.IndexedArray, "project", counted)
+
+    pairs.u + pairs.v
+    gathered = len(projections)
+
+    projections.clear()
+    _without_single_carry(monkeypatch)
+    pairs.u + pairs.v
+    per_field = len(projections)
+
+    # one index kernel per argument, instead of one per (argument, coordinate)
+    assert gathered == 2
+    assert per_field == 8
+
+
+@pytest.mark.parametrize(
+    ("operation", "expected"),
+    [
+        (lambda u, v: u.rho2, ["x", "y"]),
+        (lambda u, v: u.phi, ["x", "y"]),
+        (lambda u, v: u.deltaphi(v), ["x", "x", "y", "y"]),
+        (lambda u, v: u.deltaR(v), ["x", "x", "y", "y", "z", "z"]),
+        (lambda u, v: u.tau, ["t", "x", "y", "z"]),
+        (lambda u, v: u + v, ["t", "t", "x", "x", "y", "y", "z", "z"]),
+    ],
+)
+def test_only_the_needed_fields_are_gathered(monkeypatch, operation, expected):
+    # every field holds a distinct constant, so the buffer a carry reads names it
+    values = {"x": 1.0, "y": 2.0, "z": 3.0, "t": 10.0, "flag": 7.0}
+    zipped = ak.zip({name: [value] * 5 for name, value in values.items()})
+    pairs = ak.combinations(
+        vector.Array(ak.unflatten(zipped, [3, 0, 2])), 2, fields=["u", "v"]
+    )
+    u, v = pairs.u, pairs.v
+    carried = _carried_fields(monkeypatch, values)
+    operation(u, v)
+    assert sorted(carried) == expected
+
+
+def test_nothing_is_retained_on_the_array():
+    pairs = _pairs(("x", "y", "z", "t"), momentum=False, with_none=False)
+    u, v = pairs.u, pairs.v
+    before = set(vars(u))
+    for result in (u + v, u.rho2, u.deltaR(v)):
+        assert len(result) == len(u)
+    assert set(vars(u)) == before
+    assert not vector.backends.awkward._dispatch_operands()
+
+
+def test_unshared_indexes_are_left_untouched():
+    values = ak.contents.NumpyArray(np.array([1.0, 2.0, 3.0]))
+    record = ak.contents.RecordArray(
+        [
+            ak.contents.IndexedArray(ak.index.Index64(np.array([0, 1, 2])), values),
+            ak.contents.IndexedArray(ak.index.Index64(np.array([2, 1, 0])), values),
+        ],
+        ["x", "y"],
+        parameters={"__record__": "Vector2D"},
+    )
+    assert vector.backends.awkward._shared_index(record) is None
+
+    array = ak.Array(record, behavior=vector.backends.awkward.behavior)
+    assert vector.backends.awkward._gather_coordinates(array, ("azimuthal",)) is None
+    assert (array + array).to_list() == [
+        {"x": 2.0, "y": 6.0},
+        {"x": 4.0, "y": 4.0},
+        {"x": 6.0, "y": 2.0},
+    ]
+
+
+def test_record_parameters_survive_the_hoisted_index():
+    values = ak.contents.NumpyArray(np.array([1.0, 2.0, 3.0]))
+    index = ak.index.Index64(np.array([2, 0, 1]))
+    record = ak.contents.RecordArray(
+        [
+            ak.contents.IndexedArray(index, values),
+            ak.contents.IndexedArray(index, values),
+        ],
+        ["x", "y"],
+        parameters={"__record__": "Vector2D", "spam": "eggs"},
+    )
+    projected = vector.backends.awkward._project_one_carry(record)
+    assert projected.parameters == {"__record__": "Vector2D", "spam": "eggs"}
+    assert projected.to_list() == record.to_list()
+
+    array = ak.Array(record, behavior=vector.backends.awkward.behavior)
+    assert (array + array).to_list() == [
+        {"x": 6.0, "y": 6.0},
+        {"x": 2.0, "y": 2.0},
+        {"x": 4.0, "y": 4.0},
+    ]
+
+
+def test_shorter_record_than_its_fields_projects_its_own_rows():
+    values = ak.contents.NumpyArray(np.array([1.0, 2.0, 3.0, 4.0]))
+    index = ak.index.Index64(np.array([3, 0, 2, 1]))
+    record = ak.contents.RecordArray(
+        [
+            ak.contents.IndexedArray(index, values),
+            ak.contents.IndexedArray(index, values),
+        ],
+        ["x", "y"],
+        length=2,
+        parameters={"__record__": "Vector2D"},
+    )
+    projected = vector.backends.awkward._project_one_carry(record)
+    assert projected.length == 2
+    assert projected.to_list() == record.to_list()
+
+
+def test_dispatch_that_raises_before_its_call_leaves_no_record_behind():
+    pairs = _pairs(("x", "y", "z", "t"), momentum=False, with_none=False)
+    u, v = pairs.u, pairs.v
+    w = _pairs(("x", "y"), momentum=False, with_none=False).u
+    expected = (w.x**2 + w.y**2).to_list()
+    operands = vector.backends.awkward._dispatch_operands()
+
+    # signature lookup + wrap of ``u + v``, then the argument list raises: the
+    # dispatched function is never called
+    vector._methods._aztype(u), vector._methods._aztype(v)
+    u._wrap_dispatched_function(lambda lib, *args: None)
+    assert len(operands) == 2
+    assert all(o.source is not o.array for o in operands.values())
+
+    # the next dispatch drops them at its own wrap, before taking its elements
+    vector._methods._aztype(w)
+    w._wrap_dispatched_function(lambda lib, *args: None)
+    assert [o.array is w for o in operands.values()] == [True]
+
+    assert w.rho2.to_list() == expected
+    assert not operands

--- a/tests/backends/test_awkward.py
+++ b/tests/backends/test_awkward.py
@@ -1263,18 +1263,6 @@ def test_record_method_chaining_without_registration():
     assert result.returncode == 0, result.stderr
 
 
-# ``vector.Array`` field name for each generic coordinate, per flavor.
-_MOMENTUM_NAMES = {
-    "x": "px",
-    "y": "py",
-    "rho": "pt",
-    "phi": "phi",
-    "z": "pz",
-    "theta": "theta",
-    "eta": "eta",
-    "t": "E",
-    "tau": "mass",
-}
 # Chosen so every coordinate system is well defined (rho > 0, 0 < theta < pi) and
 # no operation below produces a NaN, which would defeat the exact comparisons.
 _COORDINATE_VALUES = {
@@ -1303,8 +1291,8 @@ _COORDINATE_SYSTEMS = [
 
 def _pairs(coordinates, *, momentum, with_none):
     """``ak.combinations`` of vectors, i.e. records behind an ``IndexedArray``."""
-    names = _MOMENTUM_NAMES if momentum else dict.fromkeys(_COORDINATE_VALUES)
-    fields = {names[name] or name: _COORDINATE_VALUES[name] for name in coordinates}
+    names = vector._methods._repr_generic_to_momentum if momentum else {}
+    fields = {names.get(name, name): _COORDINATE_VALUES[name] for name in coordinates}
     # a non-coordinate field, to check that it is never gathered or carried along
     fields["flag"] = [7.0, 8.0, 6.0, 9.0, 1.0]
     array = ak.unflatten(ak.zip(fields), [3, 0, 2])
@@ -1320,7 +1308,7 @@ def _pairs(coordinates, *, momentum, with_none):
 def _without_single_carry(monkeypatch):
     """Restore the pre-optimization path: every coordinate field gathers itself."""
     monkeypatch.setattr(
-        vector.backends.awkward, "_gather_coordinates", lambda array, groups: None
+        vector.backends.awkward, "_gather_shared_indexes", lambda arrays: arrays
     )
 
 
@@ -1422,16 +1410,6 @@ def test_only_the_needed_fields_are_gathered(monkeypatch, operation, expected):
     assert sorted(carried) == expected
 
 
-def test_nothing_is_retained_on_the_array():
-    pairs = _pairs(("x", "y", "z", "t"), momentum=False, with_none=False)
-    u, v = pairs.u, pairs.v
-    before = set(vars(u))
-    for result in (u + v, u.rho2, u.deltaR(v)):
-        assert len(result) == len(u)
-    assert set(vars(u)) == before
-    assert not vector.backends.awkward._dispatch_operands()
-
-
 def test_unshared_indexes_are_left_untouched():
     values = ak.contents.NumpyArray(np.array([1.0, 2.0, 3.0]))
     record = ak.contents.RecordArray(
@@ -1442,10 +1420,9 @@ def test_unshared_indexes_are_left_untouched():
         ["x", "y"],
         parameters={"__record__": "Vector2D"},
     )
-    assert vector.backends.awkward._shared_index(record) is None
-
     array = ak.Array(record, behavior=vector.backends.awkward.behavior)
-    assert vector.backends.awkward._gather_coordinates(array, ("azimuthal",)) is None
+    x, y = array["x"], array["y"]
+    assert vector.backends.awkward._gather_shared_indexes([x, y]) == [x, y]
     assert (array + array).to_list() == [
         {"x": 2.0, "y": 6.0},
         {"x": 4.0, "y": 4.0},
@@ -1453,64 +1430,19 @@ def test_unshared_indexes_are_left_untouched():
     ]
 
 
-def test_record_parameters_survive_the_hoisted_index():
+def test_indexed_nodes_with_parameters_are_left_untouched():
     values = ak.contents.NumpyArray(np.array([1.0, 2.0, 3.0]))
     index = ak.index.Index64(np.array([2, 0, 1]))
-    record = ak.contents.RecordArray(
-        [
-            ak.contents.IndexedArray(index, values),
-            ak.contents.IndexedArray(index, values),
-        ],
-        ["x", "y"],
-        parameters={"__record__": "Vector2D", "spam": "eggs"},
-    )
-    projected = vector.backends.awkward._project_one_carry(record)
-    assert projected.parameters == {"__record__": "Vector2D", "spam": "eggs"}
-    assert projected.to_list() == record.to_list()
-
-    array = ak.Array(record, behavior=vector.backends.awkward.behavior)
-    assert (array + array).to_list() == [
-        {"x": 6.0, "y": 6.0},
-        {"x": 2.0, "y": 2.0},
-        {"x": 4.0, "y": 4.0},
-    ]
+    x = ak.Array(ak.contents.IndexedArray(index, values, parameters={"spam": "eggs"}))
+    y = ak.Array(ak.contents.IndexedArray(index, values, parameters={"spam": "eggs"}))
+    assert vector.backends.awkward._gather_shared_indexes([x, y]) == [x, y]
 
 
-def test_shorter_record_than_its_fields_projects_its_own_rows():
-    values = ak.contents.NumpyArray(np.array([1.0, 2.0, 3.0, 4.0]))
-    index = ak.index.Index64(np.array([3, 0, 2, 1]))
-    record = ak.contents.RecordArray(
-        [
-            ak.contents.IndexedArray(index, values),
-            ak.contents.IndexedArray(index, values),
-        ],
-        ["x", "y"],
-        length=2,
-        parameters={"__record__": "Vector2D"},
-    )
-    projected = vector.backends.awkward._project_one_carry(record)
-    assert projected.length == 2
-    assert projected.to_list() == record.to_list()
-
-
-def test_dispatch_that_raises_before_its_call_leaves_no_record_behind():
-    pairs = _pairs(("x", "y", "z", "t"), momentum=False, with_none=False)
-    u, v = pairs.u, pairs.v
-    w = _pairs(("x", "y"), momentum=False, with_none=False).u
-    expected = (w.x**2 + w.y**2).to_list()
-    operands = vector.backends.awkward._dispatch_operands()
-
-    # signature lookup + wrap of ``u + v``, then the argument list raises: the
-    # dispatched function is never called
-    vector._methods._aztype(u), vector._methods._aztype(v)
-    u._wrap_dispatched_function(lambda lib, *args: None)
-    assert len(operands) == 2
-    assert all(o.source is not o.array for o in operands.values())
-
-    # the next dispatch drops them at its own wrap, before taking its elements
-    vector._methods._aztype(w)
-    w._wrap_dispatched_function(lambda lib, *args: None)
-    assert [o.array is w for o in operands.values()] == [True]
-
-    assert w.rho2.to_list() == expected
-    assert not operands
+def test_gathered_arrays_keep_behavior_and_attrs():
+    pairs = _pairs(("x", "y"), momentum=False, with_none=False)
+    x = pairs.u["x"]
+    x.attrs["note"] = "kept"
+    gathered = vector.backends.awkward._gather_shared_indexes([x, pairs.u["y"]])
+    assert gathered[0].behavior is x.behavior
+    assert gathered[0].attrs == {"note": "kept"}
+    assert gathered[0].to_list() == x.to_list()


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## What this fixes

Arithmetic on `ak.combinations` / `ak.cartesian` output spends most of its time inside
awkward, not inside vector — but the reason is something vector controls.

Those operations hand you an `IndexedArray` view. Awkward projects such a view **once per
field asked of it**, and each projection re-runs the `awkward_IndexedArray_getitem_nextcarry`
kernel over the whole index. A 4D vector asks for four coordinates, so `j1 + j2` ran
**eight** index kernels where two would do.

Separately, `dispatch` asks each operand for a coordinate group three times — `_aztype`
tests with `hasattr`, reads `type(obj.azimuthal)`, and then the argument list takes
`.elements` — and each rebuilds the group from scratch with `ak.fields` plus per-field
`__getitem__`. That is invisible on large arrays and dominant on small ones.

## Mechanism

Every one of the 82 `dispatch` functions has the same shape:

```python
function, *returns = _from_signature(__name__, dispatch_map, (_aztype(v1), _ltype(v1), ...))
...
handler._wrap_dispatched_function(function)(_lib_of(v1, v2), *v1.azimuthal.elements, ...)
```

The signature lookup asks each operand for exactly the coordinate groups the selected
function reads — `rho2` asks for azimuthal only, `deltaR` for azimuthal and longitudinal,
`add` for all three — and it always runs **before** `_wrap_dispatched_function`, which in
turn always runs before the argument list takes any `.elements`. So that one call is the
point where the needed field set is known and no element has been fetched yet.

- The coordinate properties route through `VectorAwkward._coordinates`, which records the
  group and reuses the built object for the rest of the dispatch (3 constructions -> 1).
- `_wrap_dispatched_function` gathers each operand once for exactly the recorded groups:
  slice the record to those fields, hoist the shared `Index` if awkward pushed it inside
  the record, and `project()`. An op reading `k` fields then pays **1 index kernel + k
  gathers** per operand, where `main` pays `k` kernels + k gathers.
- The record is thread-local and is cleared when the dispatch returns. **Nothing is stored
  on the array** — no instance cache, so no stale-cache question. If a dispatch raises
  between the wrap and its call (a `TypeError` from `_lib_of`, say) the record survives
  until the next dispatch on that thread, which drops it at its own wrap — before taking
  any elements, so a stale gather is never read and is never gathered again.

The gather is skipped entirely (falling back to `main`'s behaviour) for typetracer arrays —
so dask-awkward's column projection is untouched — and for flat, option-typed and
non-shared-index layouts, where there is no index to collapse. Those still get the
construction reuse.

Because the gather now happens in `_wrap_dispatched_function` rather than inside the
`azimuthal` property, an exception from the layout surgery can no longer be swallowed by
the `hasattr(obj, "azimuthal")` guard in `_aztype`.

### Kernel/gather counts

Per-field witness on `ak.combinations(4D vectors, 2)`, counting `IndexedArray.project`
and `NumpyArray._carry`:

| operation | fields carried | index kernels, `main` | index kernels, this PR |
|---|---|---|---|
| `u.rho2` | x, y | 2 | 1 |
| `u.phi` | x, y | 2 | 1 |
| `u.pt` | x, y | 2 | 1 |
| `u.deltaphi(v)` | x, y (both) | 4 | 2 |
| `u.deltaR(v)` | x, y, z (both) | 6 | 2 |
| `u.mass` | x, y, z, t | 4 | 1 |
| `u + v` | x, y, z, t (both) | 8 | 2 |

The carried-field lists are identical on both sides: this gathers **only** the fields the
dispatched function reads, never the whole record. Non-coordinate fields (`btag` and
friends) are never gathered on either side.

## Measurements

Real input: first 100k events of `Run2012B_SingleMu.root` (252,917 jets, 2,461,785
trijets from `ak.combinations(jets, 3)`), plus a synthetic flat 100k array and the file's
per-event MET. **Every number is a cold first access** — this PR keeps no cache between
dispatches, so there is no warm variant to quote. min-of-20 per run (min-of-100 for the
flat rows), best of 5 interleaved runs per side, single process, `awkward 2.13.0`,
CPython 3.13, macOS arm64.

| case | `main` (ms) | this PR (ms) | |
|---|---|---|---|
| trijet xyzt `j1+j2` | 26.93 | 19.76 | **-27%** |
| trijet xyzt `j1+j2+j3` | 41.77 | 30.79 | **-26%** |
| trijet xyzt `(j1+j2+j3).mass` | 46.33 | 35.02 | **-24%** |
| trijet ptetaphim `j1+j2` | 109.33 | 102.04 | -7% |
| trijet ptetaphim `j1+j2+j3` | 214.25 | 203.27 | -5% |
| trijet xyzt `j1.rho2` | 7.50 | 6.31 | **-16%** |
| trijet xyzt `j1.phi` | 13.13 | 11.97 | -9% |
| trijet xyzt `j1.pt` | 7.89 | 6.71 | **-15%** |
| trijet xyzt `j1.deltaphi(j2)` | 39.10 | 36.83 | -6% |
| trijet xyzt `j1.deltaR(j2)` | 83.41 | 78.64 | -6% |
| flat 100k xyzt `v+v` | 1.00 | 0.66 | **-34%** |
| flat 100k xyzt `v.mass` | 0.69 | 0.47 | **-31%** |
| flat 100k xyzt `v.deltaR(v)` | 10.11 | 9.68 | -4% |
| option-typed pairs `j1+j2` | 7.35 | 7.05 | -4% |
| option-typed pairs `j1.deltaR(j2)` | 17.48 | 17.09 | -2% |
| event MET `.deltaphi(jagged jets)` | 6.44 | 6.20 | -4% |
| event MET `+ jagged jets` (2D) | 3.16 | 2.96 | -6% |

No row is slower. The partial-coordinate rows (`rho2`, `phi`, `pt`, `deltaphi`) are the
ones an earlier revision of this branch regressed by gathering the whole record; gathering
only the dispatched groups turns them into wins. The `ptetaphim` rows gain least because
`pt/eta/phi/mass` arithmetic is transcendental-bound, not gather-bound. The option-typed
and event-broadcast rows are not gathered at all — their few percent is the construction
reuse alone.

### Memory

`u = tri.j1; u.rho2`, result discarded, measuring numpy bytes still reachable from `u`:

| | reachable from `u` before | after | pinned by the op |
|---|---|---|---|
| `main` | 25.55 MB | 25.55 MB | **0.00 MB** |
| this PR | 25.55 MB | 25.55 MB | **0.00 MB** |

Identical to `main`, as it must be: nothing is stored on the array. (The same probe reads
+39.39 MB against the instance-cache revision this branch previously carried, so it is a
live instrument, not an absent one.)

## What is left on the table

`j1 + j2` on 2.46M trijets still costs 19.8 ms, and **14.4 ms of that is awkward's gather
floor**: eight `column[index]` fancy-index reads in plain numpy over the same buffers take
14.42 ms, and adding the four sums brings it to 15.82 ms. This PR removes 7.2 ms of the
12.5 ms that sat above that floor.

One awkward-side lever is deliberately not pulled here. `IndexedArray.project` always runs
`awkward_IndexedArray_getitem_nextcarry` to build `nextcarry` from `index`, and for a plain
(non-option) `IndexedArray` the result is byte-identical to `index` — a full copy of a
2.46M-element `int64` buffer, measured at 1.17 ms per operand, so 2.34 ms of the 19.8 ms
above. Skipping that copy belongs in awkward, not in vector, and is not attempted here.

## Relation to #554

This builds directly on #554 ("perf: reduce python overhead for awkward backend", 78cd02f),
which introduced `awkward_transform` and the `_wrap_dispatched_function` hook this PR
extends. #554 fused the *compute* into one layout traversal and reported the same trijet
benchmark going ~25 ms -> 19.1 ms; it left the *reads* alone, so every coordinate field
still cost its own index projection. That is the remaining half, and it is what this
removes. I did not find an issue asking for it — #554's own thread does not mention
carries or projections.

## Tests

`tests/backends/test_awkward.py`:

- an 80-case bit-identity matrix (2 azimuthal x 10 longitudinal/temporal systems x
  generic/momentum names x with/without an option-typed sibling field) comparing `u + v`
  and `u.rho2` against the same computation with `_gather_coordinates` disabled — exact
  `to_list()` and type-string equality;
- extra (non-coordinate) fields survive one-argument ops unchanged;
- index-kernel count: 2 with the gather, 8 without;
- **needed-field witness**: each field holds a distinct constant, so the buffer every
  `NumpyArray._carry` reads names itself — `rho2`/`phi` carry exactly `x, y`, `deltaR`
  exactly `x, y, z` per operand, `tau` exactly `x, y, z, t`. Widening the gather to all
  three groups fails 4 of the 6 cases, so the assertion discriminates;
- nothing is retained on the array after `u+v`, `u.rho2`, `u.deltaR(v)`, and the
  thread-local record is empty afterwards; a dispatch that raises before its call leaves
  no record once the next dispatch wraps;
- unshared indexes are left untouched, record parameters survive the hoisted index, and a
  `RecordArray` shorter than its fields projects only its own rows.

Full suite: `942 passed, 16 skipped` (`pytest -q --ignore=tests/test_notebooks.py`;
skips are ROOT/optree/jax not installed). `pre-commit run --files` on both changed files:
all hooks pass, including `mypy` and `ruff`.

dask-awkward is unaffected: `dak.report_necessary_columns` on `(pairs.u + pairs.v).mass`
still reports `{pt, eta, phi, mass}` and on `pairs.u.pt` still reports `{pt}` — `btag` is
never touched, and the computed result matches the eager one exactly.
