### PR TITLE
feat(docs): add llms.txt and Markdown page versions

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,6 +42,7 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx_copybutton",
     "sphinx_math_dollar",
+    "sphinx_llm.txt",
 ]
 
 source_suffix = [".rst", ".md"]
@@ -63,6 +64,14 @@ templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 autodoc_mock_imports = ["numba"]
+
+# -- Options for LLM-friendly output -----------------------------------------
+
+# The default is the full README, which is too long for the summary block
+llms_txt_description = (
+    "Documentation of the Vector library for 2D, 3D, and Lorentz vectors,"
+    " including the object, NumPy, Awkward, SymPy, and Numba backends."
+)
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,8 @@
 ---
 myst:
   html_meta:
-    description: Vector is a Python library for 2D, 3D, and Lorentz vectors, with
+    description:
+      Vector is a Python library for 2D, 3D, and Lorentz vectors, with
       object, NumPy, Awkward, SymPy, and Numba backends.
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,10 @@
+---
+myst:
+  html_meta:
+    description: Vector is a Python library for 2D, 3D, and Lorentz vectors, with
+      object, NumPy, Awkward, SymPy, and Numba backends.
+---
+
 ![](_images/LogoSrc.svg)
 
 # Overview

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,7 @@ docs = [
   "sphinx-book-theme>=0.0.42",
   "sphinx-copybutton",
   "sphinx-math-dollar",
+  "sphinx-llm",
   "hepunits>=2.4.0",
   "matplotlib",
 ]


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Adds LLM-friendly docs output with NVIDIA's `sphinx-llm` (`sphinx_llm.txt` extension). It runs the markdown builder alongside the HTML build and merges the results, so the whole thing is one extension and one build:

- `llms.txt` — sitemap with a one-line description per page.
- `llms-full.txt` — all docs in one file.
- `<page>.html.md` next to each `<page>.html`.

`llms_txt_description` is set because the default summary is the full README. The index page got a `description` meta tag, since `llms.txt` otherwise used the logo image line as its summary.

Same change as scikit-hep/uhi#252. Built locally with no new warnings.